### PR TITLE
Left align books in the horizontal book list

### DIFF
--- a/components/BookCardCover.js
+++ b/components/BookCardCover.js
@@ -51,7 +51,6 @@ export default ({ book, ...props }: { book: Book }) => (
   <Box
     w={[105, 130]}
     h={['164px', '204px']}
-    mx={5}
     style={{ flexShrink: 0 }}
     {...props}
   >

--- a/components/HorizontalBookList.js
+++ b/components/HorizontalBookList.js
@@ -12,13 +12,10 @@ import type { Book } from '../types';
 import BookCardCover from './BookCardCover';
 import { Link } from '../routes';
 
-const FlexScroller = Flex.extend`
-  justify-content: space-between;
-  overflow-x: auto;
-`;
+const FlexScroller = Flex.extend`overflow-x: auto;`;
 
 export default ({ books, ...props }: { books: Array<Book> }) => (
-  <FlexScroller {...props}>
+  <FlexScroller mx={-8} {...props}>
     {books.map(book => (
       <Link
         route="book"
@@ -26,7 +23,7 @@ export default ({ books, ...props }: { books: Array<Book> }) => (
         key={book.id}
         passHref
       >
-        <BookCardCover book={book} is="a" />
+        <BookCardCover book={book} mx={8} is="a" />
       </Link>
     ))}
   </FlexScroller>


### PR DESCRIPTION
Previously the flex container evenely distributed it's items, which was
problematic in those cases where there were fewer than 5 books in the
list.

Fixes GlobalDigitalLibraryio/issues#69