### PR TITLE
Close toolbar dropdown when clicking item

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "compression": "1.7.1",
     "cookie-parser": "1.4.3",
     "domurl": "2.1.7",
-    "downshift": "1.15.0",
+    "downshift": "1.16.0",
     "express": "4.16.2",
     "express-request-language": "1.1.12",
     "glob": "7.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2790,9 +2790,9 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-downshift@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.15.0.tgz#2923a163c7ae836ea29e0ba62ec0efefc0dd6c87"
+downshift@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.16.0.tgz#1efd71ca987b849989b27468f5b46fc1adde426e"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Next.js's <Link /> overwrites any onClick on it's child. So for now we
work around this to get the wanted effect of closing the dropdown on
selection

Resolves GlobalDigitalLibraryio/issues#67