### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/components/BookGrid.js
+++ b/components/BookGrid.js
@@ -12,14 +12,15 @@ import type { Book } from '../types';
 import BookCardCover from './BookCardCover';
 import { Link } from '../routes';
 
-export default ({ books, ...props }: { books: Array<Book> }) => (
+type Props = {
+  books: Array<Book>,
+  route(book: Book): string,
+};
+
+const BookGrid = ({ books, route, ...props }: Props) => (
   <Flex wrap mx={-6} {...props}>
     {books.map(book => (
-      <Link
-        route="book"
-        params={{ id: book.id, lang: book.language.code }}
-        key={book.id}
-      >
+      <Link route={route(book)} key={book.id}>
         <a>
           <BookCardCover book={book} mx={6} mb={20} />
         </a>
@@ -27,3 +28,5 @@ export default ({ books, ...props }: { books: Array<Book> }) => (
     ))}
   </Flex>
 );
+
+export default BookGrid;

--- a/components/BookList.js
+++ b/components/BookList.js
@@ -18,17 +18,13 @@ const FlexScroller = Flex.extend`
 
 type Props = {
   books: Array<Book>,
-  route: 'book' | 'bookByLevel' | 'bookByNew',
+  route(book: Book): string,
 };
 
 const BookList = ({ books, route, ...props }: Props) => (
   <FlexScroller mx={-6} {...props}>
     {books.map(book => (
-      <Link
-        route={route}
-        params={{ id: book.id, lang: book.language.code }}
-        key={book.id}
-      >
+      <Link route={route(book)} key={book.id}>
         <a>
           <BookCardCover book={book} mx={6} />
         </a>
@@ -38,7 +34,7 @@ const BookList = ({ books, route, ...props }: Props) => (
 );
 
 BookList.defaultProps = {
-  route: 'book',
+  route: (book: Book) => `/${book.language.code}/books/${book.id}`,
 };
 
 export default BookList;

--- a/components/BookList.js
+++ b/components/BookList.js
@@ -16,11 +16,16 @@ const FlexScroller = Flex.extend`
   overflow-x: auto;
 `;
 
-export default ({ books, ...props }: { books: Array<Book> }) => (
+type Props = {
+  books: Array<Book>,
+  route: 'book' | 'bookByLevel' | 'bookByNew',
+};
+
+const BookList = ({ books, route, ...props }: Props) => (
   <FlexScroller mx={-6} {...props}>
     {books.map(book => (
       <Link
-        route="book"
+        route={route}
         params={{ id: book.id, lang: book.language.code }}
         key={book.id}
       >
@@ -31,3 +36,9 @@ export default ({ books, ...props }: { books: Array<Book> }) => (
     ))}
   </FlexScroller>
 );
+
+BookList.defaultProps = {
+  route: 'book',
+};
+
+export default BookList;

--- a/components/Breadcrumb/Breadcrumb.js
+++ b/components/Breadcrumb/Breadcrumb.js
@@ -1,0 +1,75 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ *
+ * See LICENSE
+ */
+
+import * as React from 'react';
+import { MdKeyboardArrowRight, MdHome } from 'react-icons/lib/md';
+import type { I18n } from 'lingui-i18n';
+import { withI18n } from 'lingui-react';
+import styled from 'styled-components';
+import { Link } from '../../routes';
+
+const Ol = styled.ol`
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+
+  li {
+    display: flex;
+    align-items: center;
+  }
+  li:last-child {
+    font-weight: 500;
+  }
+`;
+
+type Props = {
+  i18n: I18n,
+  currentPage: string,
+};
+
+const Separator = (
+  <li aria-hidden role="presentation">
+    <MdKeyboardArrowRight />
+  </li>
+);
+
+class Breadcrumb extends React.Component<Props> {
+  renderHome() {
+    if (this.props.currentPage) {
+      return [
+        <li>
+          <Link route="books" passHref>
+            <a aria-label="Home" title="Home">
+              <MdHome />
+            </a>
+          </Link>
+        </li>,
+        Separator,
+      ];
+    }
+    return null;
+  }
+
+  render() {
+    const { currentPage } = this.props;
+    return (
+      <nav aria-label={this.props.i18n.t`Breadcrumb`} role="navigation">
+        <Ol>
+          {this.renderHome()}
+          <li aria-current="page" aria-label={currentPage ? 'Home' : null}>
+            {currentPage || <MdHome />}
+          </li>
+        </Ol>
+      </nav>
+    );
+  }
+}
+
+export default withI18n()(Breadcrumb);

--- a/components/Breadcrumb/Breadcrumb.js
+++ b/components/Breadcrumb/Breadcrumb.js
@@ -38,10 +38,11 @@ const Ol = styled.ol`
 type Props = {
   i18n: I18n,
   currentPage?: string,
+  lang: string,
 };
 
 const Separator = (
-  <li aria-hidden role="presentation">
+  <li aria-hidden role="presentation" key="sep">
     <MdKeyboardArrowRight />
   </li>
 );
@@ -50,8 +51,8 @@ class Breadcrumb extends React.Component<Props> {
   renderHome() {
     if (this.props.currentPage) {
       return [
-        <li>
-          <Link route="books" passHref>
+        <li key="home">
+          <Link route="books" passHref params={{ lang: this.props.lang }}>
             <a aria-label="Home" title="Home">
               <MdHome />
             </a>

--- a/components/Breadcrumb/Breadcrumb.js
+++ b/components/Breadcrumb/Breadcrumb.js
@@ -37,8 +37,14 @@ const Ol = styled.ol`
 
 type Props = {
   i18n: I18n,
-  currentPage?: string,
+  currentPage: ?string,
   lang: string,
+  router: {
+    asPath: string,
+    query: {
+      [string]: ?string,
+    },
+  },
 };
 
 const Separator = (
@@ -49,33 +55,66 @@ const Separator = (
 
 class Breadcrumb extends React.Component<Props> {
   renderHome() {
+    // Render as link
     if (this.props.currentPage) {
-      return [
-        <li key="home">
-          <Link route="books" passHref params={{ lang: this.props.lang }}>
-            <a aria-label="Home" title="Home">
+      return (
+        <li>
+          <Link route="books" params={{ lang: this.props.lang }}>
+            <a title="Home" aria-label="Home">
               <MdHome />
             </a>
           </Link>
-        </li>,
-        Separator,
-      ];
+        </li>
+      );
     }
+    // Render as not a link :p
+    return (
+      <li aria-current="page">
+        <MdHome aria-label="Home" />
+      </li>
+    );
+  }
+
+  renderMiddlePart() {
+    const { query, asPath } = this.props.router;
+    const { lang } = this.props;
+
+    if (query.level && query.id) {
+      return (
+        <li>
+          <Link route={`/${lang}/books/level${query.level}`}>
+            <a>Level {query.level}</a>
+          </Link>
+        </li>
+      );
+    } else if (query.id && asPath.includes('/new/')) {
+      return (
+        <li>
+          <Link route={`/${lang}/books/new`}>
+            <a>New arrivals</a>
+          </Link>
+        </li>
+      );
+    }
+
     return null;
   }
 
   render() {
-    const { currentPage, i18n } = this.props;
+    const { i18n, currentPage } = this.props;
+
+    const middle = this.renderMiddlePart();
+
     return (
       <Nav aria-label={i18n.t`Breadcrumb`} role="navigation">
         <Ol>
           {this.renderHome()}
-          <li
-            aria-current="page"
-            aria-label={currentPage ? i18n.t`Home` : null}
-          >
-            {currentPage || <MdHome />}
-          </li>
+          {middle && Separator}
+          {middle}
+          {currentPage && [
+            Separator,
+            <li aria-current="page">{currentPage}</li>,
+          ]}
         </Ol>
       </Nav>
     );

--- a/components/Breadcrumb/Breadcrumb.js
+++ b/components/Breadcrumb/Breadcrumb.js
@@ -13,6 +13,12 @@ import { withI18n } from 'lingui-react';
 import styled from 'styled-components';
 import { Link } from '../../routes';
 
+const Nav = styled.nav`
+  display: flex;
+  align-items: stretch;
+  flex: 1;
+`;
+
 const Ol = styled.ol`
   display: flex;
   list-style: none;
@@ -31,7 +37,7 @@ const Ol = styled.ol`
 
 type Props = {
   i18n: I18n,
-  currentPage: string,
+  currentPage?: string,
 };
 
 const Separator = (
@@ -58,16 +64,19 @@ class Breadcrumb extends React.Component<Props> {
   }
 
   render() {
-    const { currentPage } = this.props;
+    const { currentPage, i18n } = this.props;
     return (
-      <nav aria-label={this.props.i18n.t`Breadcrumb`} role="navigation">
+      <Nav aria-label={i18n.t`Breadcrumb`} role="navigation">
         <Ol>
           {this.renderHome()}
-          <li aria-current="page" aria-label={currentPage ? 'Home' : null}>
+          <li
+            aria-current="page"
+            aria-label={currentPage ? i18n.t`Home` : null}
+          >
             {currentPage || <MdHome />}
           </li>
         </Ol>
-      </nav>
+      </Nav>
     );
   }
 }

--- a/components/Breadcrumb/index.js
+++ b/components/Breadcrumb/index.js
@@ -1,0 +1,11 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ * 
+ * See LICENSE
+ */
+
+import Breadcrumb from './Breadcrumb';
+
+export default Breadcrumb;

--- a/components/Error.js
+++ b/components/Error.js
@@ -27,9 +27,10 @@ export default class Error extends React.Component<Props> {
 
   render() {
     const { statusCode, showNavbar } = this.props;
+    // FIXME: lang prop in navbar here :/
     return (
       <div>
-        {showNavbar && <Navbar />}
+        {showNavbar && <Navbar lang="eng" />}
         <Container mt={[15, 40]}>
           <Card px={17} py={24} textAlign="center">
             <H1>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,32 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ *
+ * See LICENSE
+ */
+
+import * as React from 'react';
+import Navbar from './Navbar';
+import Breadcrumb from './Breadcrumb';
+import Container from './Container';
+import Toolbar from './Toolbar';
+
+type Props = {
+  children: React.Node,
+  currentPage: string,
+};
+
+const Layout = ({ children, currentPage }: Props) => (
+  <div>
+    <Navbar />
+    <Toolbar>
+      <Container mw="1075px">
+        <Breadcrumb currentPage={currentPage} />
+      </Container>
+    </Toolbar>
+    {children}
+  </div>
+);
+
+export default Layout;

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -8,6 +8,7 @@
 
 import * as React from 'react';
 import styled from 'styled-components';
+import { withRouter } from 'next/router';
 import media from './helpers/media';
 import Navbar from './Navbar';
 import Breadcrumb from './Breadcrumb';
@@ -17,7 +18,12 @@ type Props = {
   children: React.Node,
   currentPage?: string,
   toolbarEnd?: React.Node,
-  lang: string,
+  router: {
+    query: {
+      lang?: string,
+    },
+    asPath: string,
+  },
 };
 
 const Toolbar = styled.div`
@@ -36,12 +42,12 @@ const Toolbar = styled.div`
   }
 `;
 
-const Layout = ({ children, toolbarEnd, currentPage, lang }: Props) => (
+const Layout = ({ children, toolbarEnd, currentPage, router }: Props) => (
   <div>
-    <Navbar lang={lang} />
+    <Navbar lang={router.query.lang} />
     <Toolbar>
       <Container mw="1075px">
-        <Breadcrumb currentPage={currentPage} lang={lang} />
+        <Breadcrumb currentPage={currentPage} lang={router.query.lang} />
         {toolbarEnd}
       </Container>
     </Toolbar>
@@ -49,4 +55,4 @@ const Layout = ({ children, toolbarEnd, currentPage, lang }: Props) => (
   </div>
 );
 
-export default Layout;
+export default withRouter(Layout);

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -7,22 +7,35 @@
  */
 
 import * as React from 'react';
+import styled from 'styled-components';
 import Navbar from './Navbar';
 import Breadcrumb from './Breadcrumb';
 import Container from './Container';
-import Toolbar from './Toolbar';
 
 type Props = {
   children: React.Node,
-  currentPage: string,
+  currentPage?: string,
+  toolbarEnd?: React.Node,
 };
 
-const Layout = ({ children, currentPage }: Props) => (
+const Toolbar = styled.div`
+  background: ${props => props.theme.grays.white};
+  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.12);
+  font-size: 14px;
+  position: relative;
+  ${Container} {
+    width: 100%;
+    display: flex;
+  }
+`;
+
+const Layout = ({ children, toolbarEnd, currentPage }: Props) => (
   <div>
     <Navbar />
     <Toolbar>
       <Container mw="1075px">
         <Breadcrumb currentPage={currentPage} />
+        {toolbarEnd}
       </Container>
     </Toolbar>
     {children}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -16,13 +16,12 @@ import Container from './Container';
 
 type Props = {
   children: React.Node,
-  currentPage?: string,
   toolbarEnd?: React.Node,
+  currentPage?: string,
   router: {
     query: {
       lang?: string,
     },
-    asPath: string,
   },
 };
 
@@ -36,9 +35,8 @@ const Toolbar = styled.div`
     font-size: 14px;
     height: 38px;
   `} ${Container} {
-    width: 100%;
-    height: 100%;
     display: flex;
+    height: 100%;
   }
 `;
 
@@ -47,7 +45,11 @@ const Layout = ({ children, toolbarEnd, currentPage, router }: Props) => (
     <Navbar lang={router.query.lang} />
     <Toolbar>
       <Container mw="1075px">
-        <Breadcrumb currentPage={currentPage} lang={router.query.lang} />
+        <Breadcrumb
+          lang={router.query.lang}
+          router={router}
+          currentPage={currentPage}
+        />
         {toolbarEnd}
       </Container>
     </Toolbar>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -8,6 +8,7 @@
 
 import * as React from 'react';
 import styled from 'styled-components';
+import media from './helpers/media';
 import Navbar from './Navbar';
 import Breadcrumb from './Breadcrumb';
 import Container from './Container';
@@ -16,25 +17,31 @@ type Props = {
   children: React.Node,
   currentPage?: string,
   toolbarEnd?: React.Node,
+  lang: string,
 };
 
 const Toolbar = styled.div`
   background: ${props => props.theme.grays.white};
   box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.12);
-  font-size: 14px;
   position: relative;
-  ${Container} {
+  font-size: 12px;
+  height: 28px;
+  ${media.tablet`
+    font-size: 14px;
+    height: 38px;
+  `} ${Container} {
     width: 100%;
+    height: 100%;
     display: flex;
   }
 `;
 
-const Layout = ({ children, toolbarEnd, currentPage }: Props) => (
+const Layout = ({ children, toolbarEnd, currentPage, lang }: Props) => (
   <div>
-    <Navbar />
+    <Navbar lang={lang} />
     <Toolbar>
       <Container mw="1075px">
-        <Breadcrumb currentPage={currentPage} />
+        <Breadcrumb currentPage={currentPage} lang={lang} />
         {toolbarEnd}
       </Container>
     </Toolbar>

--- a/components/Navbar/Navbar.js
+++ b/components/Navbar/Navbar.js
@@ -73,7 +73,7 @@ const LogoA = styled.a`
 `;
 
 type Props = {
-  lang: string,
+  lang: ?string,
 };
 
 class Navbar extends React.Component<Props, { isExpanded: boolean }> {

--- a/components/Navbar/Navbar.js
+++ b/components/Navbar/Navbar.js
@@ -72,7 +72,11 @@ const LogoA = styled.a`
   }
 `;
 
-class Navbar extends React.Component<{}, { isExpanded: boolean }> {
+type Props = {
+  lang: string,
+};
+
+class Navbar extends React.Component<Props, { isExpanded: boolean }> {
   state = {
     isExpanded: false,
   };
@@ -99,7 +103,11 @@ class Navbar extends React.Component<{}, { isExpanded: boolean }> {
             </HamburgerButton>
           </Flex>
           <Flex justify={['center', 'flex-start']} flex="1 1 0">
-            <Link route="books" passHref>
+            <Link
+              route="books"
+              passHref
+              params={this.props.lang ? { lang: this.props.lang } : {}}
+            >
               <LogoA>
                 <Logo style={{ height: '35px' }} />
               </LogoA>

--- a/components/Toolbar.js
+++ b/components/Toolbar.js
@@ -23,8 +23,7 @@ const Toolbar = styled.div`
   ${Container} {
     width: 100%;
     display: flex;
-    justify-content: flex-end;
-    padding: 0;
+    align-items: stretch;
   }
 `;
 

--- a/components/ToolbarDropdown.js
+++ b/components/ToolbarDropdown.js
@@ -9,39 +9,19 @@ import * as React from 'react';
 import Downshift from 'downshift';
 import styled from 'styled-components';
 import { MdKeyboardArrowDown, MdKeyboardArrowUp } from 'react-icons/lib/md';
-import media from './helpers/media';
-import Container from './Container';
 import Card from './Card';
 
 /* eslint-disable react/no-multi-comp */
 
-const Toolbar = styled.div`
-  background: ${props => props.theme.grays.white};
-  box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.12), 0 2px 2px 0 rgba(0, 0, 0, 0.12);
-  font-size: 14px;
-  position: relative;
-  ${Container} {
-    width: 100%;
-    display: flex;
-    align-items: stretch;
-  }
-`;
-
 const Item = styled.div`
   position: relative;
   display: inline-block;
-  padding-right: 15px;
-  ${media.tablet`
-    padding-right: 20px;
-  `};
 `;
 
 const DropdownButton = styled.a.attrs({
   href: '',
 })`
   display: block;
-  padding-top: 7px;
-  padding-bottom: 7px;
 `;
 
 const DropdownItemAnchor = styled.a`
@@ -143,4 +123,4 @@ class ToolbarItem extends React.Component<Props> {
   }
 }
 
-export { Toolbar as default, ToolbarItem, ToolbarDropdownItem };
+export { ToolbarItem as default, ToolbarDropdownItem };

--- a/components/ToolbarDropdown.js
+++ b/components/ToolbarDropdown.js
@@ -15,14 +15,13 @@ import Card from './Card';
 
 const Item = styled.div`
   position: relative;
-  display: inline-block;
+  display: flex;
+  align-items: center;
 `;
 
 const DropdownButton = styled.a.attrs({
   href: '',
-})`
-  display: block;
-`;
+})``;
 
 const DropdownItemAnchor = styled.a`
   display: block;

--- a/components/__tests__/ToolbarDropdown.test.js
+++ b/components/__tests__/ToolbarDropdown.test.js
@@ -12,7 +12,7 @@ import { mount } from 'enzyme';
 import Link from 'next/link';
 import Router from 'next/router';
 import type { Language } from '../../types';
-import { ToolbarItem, ToolbarDropdownItem } from '../Toolbar';
+import ToolbarItem, { ToolbarDropdownItem } from '../ToolbarDropdown';
 import { theme } from '../../hocs/withTheme';
 
 const languages: Array<Language> = [

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -134,7 +134,7 @@ class BookPage extends React.Component<Props> {
     const availableLanguages = book.availableLanguages.length - 1;
 
     return (
-      <Layout currentPage={book.title}>
+      <Layout currentPage={book.title} lang={book.language.code}>
         <Meta
           title={book.title}
           description={book.description}

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -23,7 +23,7 @@ import defaultPage from '../../hocs/defaultPage';
 import { Link, Router } from '../../routes';
 import Box from '../../components/Box';
 import Flex from '../../components/Flex';
-import Navbar from '../../components/Navbar';
+import Layout from '../../components/Layout';
 import ReadingLevel from '../../components/ReadingLevel';
 import A from '../../components/A';
 import H3 from '../../components/H3';
@@ -134,13 +134,12 @@ class BookPage extends React.Component<Props> {
     const availableLanguages = book.availableLanguages.length - 1;
 
     return (
-      <div>
+      <Layout currentPage={book.title}>
         <Meta
           title={book.title}
           description={book.description}
           image={book.coverPhoto ? book.coverPhoto.large : null}
         />
-        <Navbar />
 
         {this.props.url.query.chapter && (
           <Reader
@@ -317,7 +316,7 @@ class BookPage extends React.Component<Props> {
             <BookList books={similar.results} mt={20} />
           </Container>
         </Hero>
-      </div>
+      </Layout>
     );
   }
 }

--- a/pages/books/index.js
+++ b/pages/books/index.js
@@ -134,7 +134,7 @@ class BookPage extends React.Component<Props> {
     const availableLanguages = book.availableLanguages.length - 1;
 
     return (
-      <Layout currentPage={book.title} lang={book.language.code}>
+      <Layout currentPage={book.title}>
         <Meta
           title={book.title}
           description={book.description}

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -9,7 +9,7 @@
 import * as React from 'react';
 import { Trans } from 'lingui-react';
 import { fetchBooks } from '../../fetch';
-import type { Book, RemoteData } from '../../types';
+import type { Book, RemoteData, Language } from '../../types';
 import defaultPage from '../../hocs/defaultPage';
 import Layout from '../../components/Layout';
 import H1 from '../../components/H1';
@@ -20,6 +20,7 @@ import BookGrid from '../../components/BookGrid';
 type Props = {
   books: RemoteData<{
     results: Array<Book>,
+    language: Language,
   }>,
   level: ?string,
 };
@@ -41,7 +42,10 @@ class BookPage extends React.Component<Props> {
     const { books, level } = this.props;
 
     return (
-      <Layout currentPage={level ? `Level ${level}` : 'New arrivals'}>
+      <Layout
+        currentPage={level ? `Level ${level}` : 'New arrivals'}
+        lang={books.language.code}
+      >
         <Meta
           title={level ? `Level ${level} books` : 'New arrivals'}
           description="More books"

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -41,6 +41,11 @@ class BookPage extends React.Component<Props> {
   render() {
     const { books, level } = this.props;
 
+    // The route to book differs based on "where we come from". This is because of breadcrumbs
+    const route = level
+      ? (book: Book) => `/${book.language.code}/books/level${level}/${book.id}`
+      : (book: Book) => `/${book.language.code}/books/new/${book.id}`;
+
     return (
       <Layout
         currentPage={level ? `Level ${level}` : 'New arrivals'}
@@ -65,7 +70,7 @@ class BookPage extends React.Component<Props> {
               <Trans>No books found</Trans>
             </H1>
           )}
-          <BookGrid books={books.results} />
+          <BookGrid books={books.results} route={route} />
         </Container>
       </Layout>
     );

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -11,7 +11,7 @@ import { Trans } from 'lingui-react';
 import { fetchBooks } from '../../fetch';
 import type { Book, RemoteData } from '../../types';
 import defaultPage from '../../hocs/defaultPage';
-import Navbar from '../../components/Navbar';
+import Layout from '../../components/Layout';
 import H1 from '../../components/H1';
 import Container from '../../components/Container';
 import Meta from '../../components/Meta';
@@ -41,12 +41,11 @@ class BookPage extends React.Component<Props> {
     const { books, level } = this.props;
 
     return (
-      <div>
+      <Layout currentPage={level ? `Level ${level}` : 'New arrivals'}>
         <Meta
           title={level ? `Level ${level} books` : 'New arrivals'}
           description="More books"
         />
-        <Navbar />
 
         <Container pt={20}>
           {books.results.length > 0 ? (
@@ -64,7 +63,7 @@ class BookPage extends React.Component<Props> {
           )}
           <BookGrid books={books.results} />
         </Container>
-      </div>
+      </Layout>
     );
   }
 }

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -47,10 +47,7 @@ class BookPage extends React.Component<Props> {
       : (book: Book) => `/${book.language.code}/books/new/${book.id}`;
 
     return (
-      <Layout
-        currentPage={level ? `Level ${level}` : 'New arrivals'}
-        lang={books.language.code}
-      >
+      <Layout currentPage={level ? `Level ${level}` : 'New arrivals'}>
         <Meta
           title={level ? `Level ${level} books` : 'New arrivals'}
           description="More books"

--- a/pages/index.js
+++ b/pages/index.js
@@ -18,9 +18,9 @@ import {
 } from '../fetch';
 import type { Book, Language, RemoteData } from '../types';
 import defaultPage from '../hocs/defaultPage';
+import Layout from '../components/Layout';
 import Box from '../components/Box';
 import Flex from '../components/Flex';
-import Navbar from '../components/Navbar';
 import Card from '../components/Card';
 import BookCover from '../components/BookCover';
 import { Link } from '../routes';
@@ -32,10 +32,9 @@ import P from '../components/P';
 import H3 from '../components/H3';
 import H4 from '../components/H4';
 import More from '../components/More';
-import Toolbar, {
-  ToolbarItem,
+import ToolbarDropdown, {
   ToolbarDropdownItem,
-} from '../components/Toolbar';
+} from '../components/ToolbarDropdown';
 
 const LANG_QUERY = 'lang';
 
@@ -87,42 +86,39 @@ class BooksPage extends React.Component<Props> {
     const languageFilter = justArrived.language;
 
     return (
-      <div>
-        <Meta title={i18n.t`Books`} description={i18n.t`Enjoy all the books`} />
-        <Navbar />
-
-        <Toolbar>
-          <Container mw="1075px" px={[0, 15]}>
-            <ToolbarItem
-              id="langFilter"
-              text={
-                <Trans>
-                  Books in <strong>{languageFilter.name}</strong>
-                </Trans>
-              }
-              selectedItem={languageFilter.code}
-            >
-              {({ getItemProps, selectedItem, highlightedIndex }) =>
-                languages.map((language, index) => (
-                  <Link
-                    key={language.code}
-                    route="books"
-                    passHref
-                    params={{ [LANG_QUERY]: language.code }}
+      <Layout
+        toolbarEnd={
+          <ToolbarDropdown
+            id="langFilter"
+            text={
+              <Trans>
+                Books in <strong>{languageFilter.name}</strong>
+              </Trans>
+            }
+            selectedItem={languageFilter.code}
+          >
+            {({ getItemProps, selectedItem, highlightedIndex }) =>
+              languages.map((language, index) => (
+                <Link
+                  key={language.code}
+                  route="books"
+                  passHref
+                  params={{ [LANG_QUERY]: language.code }}
+                >
+                  <ToolbarDropdownItem
+                    {...getItemProps({ item: language.code })}
+                    isActive={highlightedIndex === index}
+                    isSelected={selectedItem === language.code}
                   >
-                    <ToolbarDropdownItem
-                      {...getItemProps({ item: language.code })}
-                      isActive={highlightedIndex === index}
-                      isSelected={selectedItem === language.code}
-                    >
-                      <MdCheck />
-                      {language.name}
-                    </ToolbarDropdownItem>
-                  </Link>
-                ))}
-            </ToolbarItem>
-          </Container>
-        </Toolbar>
+                    <MdCheck />
+                    {language.name}
+                  </ToolbarDropdownItem>
+                </Link>
+              ))}
+          </ToolbarDropdown>
+        }
+      >
+        <Meta title={i18n.t`Books`} description={i18n.t`Enjoy all the books`} />
 
         <Hero
           colorful
@@ -202,7 +198,7 @@ class BooksPage extends React.Component<Props> {
             </Container>
           </Hero>
         ))}
-      </div>
+      </Layout>
     );
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -87,6 +87,7 @@ class BooksPage extends React.Component<Props> {
 
     return (
       <Layout
+        lang={languageFilter.code}
         toolbarEnd={
           <ToolbarDropdown
             id="langFilter"

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,8 +36,6 @@ import ToolbarDropdown, {
   ToolbarDropdownItem,
 } from '../components/ToolbarDropdown';
 
-const LANG_QUERY = 'lang';
-
 type Props = {
   editorPicks: RemoteData<Array<Book>>,
   justArrived: RemoteData<{ results: Array<Book>, language: Language }>,
@@ -49,7 +47,7 @@ type Props = {
 
 class BooksPage extends React.Component<Props> {
   static async getInitialProps({ query }) {
-    const language: ?string = query[LANG_QUERY];
+    const language: ?string = query.lang;
 
     // Fetch these first, cause they don't use the reading level
     const [editorPicks, levels, languages, justArrived] = await Promise.all([
@@ -104,7 +102,7 @@ class BooksPage extends React.Component<Props> {
                   key={language.code}
                   route="books"
                   passHref
-                  params={{ [LANG_QUERY]: language.code }}
+                  params={{ lang: language.code }}
                 >
                   <ToolbarDropdownItem
                     {...getItemProps({ item: language.code })}
@@ -177,7 +175,7 @@ class BooksPage extends React.Component<Props> {
                 </More>
               </Link>
             </H3>
-            <BookList books={justArrived.results} mt={20} />
+            <BookList books={justArrived.results} route="bookByNew" mt={20} />
           </Container>
         </Hero>
         {levels.map((level, index) => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -174,7 +174,12 @@ class BooksPage extends React.Component<Props> {
                 </More>
               </Link>
             </H3>
-            <BookList books={justArrived.results} route="bookByNew" mt={20} />
+            <BookList
+              books={justArrived.results}
+              mt={20}
+              route={(book: Book) =>
+                `/${book.language.code}/books/new/${book.id}`}
+            />
           </Container>
         </Hero>
         {levels.map((level, index) => (
@@ -192,7 +197,12 @@ class BooksPage extends React.Component<Props> {
                   </More>
                 </Link>
               </H3>
-              <BookList books={booksByLevel[index].results} mt={20} />
+              <BookList
+                books={booksByLevel[index].results}
+                route={(book: Book) =>
+                  `/${book.language.code}/books/level${level}/${book.id}`}
+                mt={20}
+              />
             </Container>
           </Hero>
         ))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -85,7 +85,6 @@ class BooksPage extends React.Component<Props> {
 
     return (
       <Layout
-        lang={languageFilter.code}
         toolbarEnd={
           <ToolbarDropdown
             id="langFilter"

--- a/routes.js
+++ b/routes.js
@@ -20,17 +20,18 @@ if (env.IS_PROD) {
   routes.add('about');
 }
 
-// Book grid by level
-routes.add('level', '/:lang/books/level:level(\\d+)', 'books/more');
+// Book grid by level (we only allow a single digit for level, so no + in the regex)
+routes.add('level', '/:lang/books/level:level(\\d)', 'books/more');
 // Book grid for new books
 routes.add('new', '/:lang/books/new', 'books/more');
 
 // Book page
 routes.add('book', '/:lang/books/:id(\\d+)/:chapter(\\d+)?', 'books/index');
 routes.add('bookByNew', '/:lang/books/new/:id(\\d+)', 'books/index');
+// We only allow a single digit in the level, so no + in the regex
 routes.add(
   'bookByLevel',
-  '/:lang/books/level:level(\\d+)/:id(\\d+)',
+  '/:lang/books/level:level(\\d)/:id(\\d+)',
   'books/index',
 );
 

--- a/routes.js
+++ b/routes.js
@@ -16,17 +16,23 @@ if (env.IS_PROD) {
   routes.add('books', '/books', 'index');
 } else {
   // in other environments we want the books page to be the landing page
-  routes.add('books', '/', 'index');
+  routes.add('books', '/:lang?', 'index');
   routes.add('about');
 }
 
 // Book grid by level
-routes.add('level', '/books/:lang/level:level(\\d+)', 'books/more');
+routes.add('level', '/:lang/books/level:level(\\d+)', 'books/more');
 // Book grid for new books
-routes.add('new', '/books/:lang/new', 'books/more');
+routes.add('new', '/:lang/books/new', 'books/more');
 
 // Book page
-routes.add('book', '/books/:lang/:id(\\d+)/:chapter(\\d+)?', 'books/index');
+routes.add('book', '/:lang/books/:id(\\d+)/:chapter(\\d+)?', 'books/index');
+routes.add('bookByNew', '/:lang/books/new/:id(\\d+)', 'books/index');
+routes.add(
+  'bookByLevel',
+  '/:lang/books/level:level(\\d+)/:id(\\d+)',
+  'books/index',
+);
 
 // About the global digital library
 routes.add(

--- a/stories/NavExample.js
+++ b/stories/NavExample.js
@@ -10,4 +10,4 @@ import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import Navbar from '../components/Navbar';
 
-storiesOf('Navbar', module).add('Navbar', () => <Navbar />);
+storiesOf('Navbar', module).add('Navbar', () => <Navbar lang="eng" />);

--- a/stories/ToolbarExample.js
+++ b/stories/ToolbarExample.js
@@ -9,10 +9,9 @@
 import * as React from 'react';
 import { storiesOf } from '@storybook/react';
 import { MdCheck } from 'react-icons/lib/md';
-import Toolbar, {
-  ToolbarItem,
+import ToolbarDropdown, {
   ToolbarDropdownItem,
-} from '../components/Toolbar';
+} from '../components/ToolbarDropdown';
 import type { Language } from '../types';
 import Container from '../components/Container';
 
@@ -25,36 +24,34 @@ const languages: Array<Language> = [
 const levels = ['1', '2', '3'];
 
 storiesOf('Toolbar', module).add('Toolbar', () => (
-  <Toolbar>
-    <Container>
-      <ToolbarItem id="langFilter" text="Language" selectedItem="eng">
-        {({ getItemProps, selectedItem, highlightedIndex }) =>
-          languages.map((lang, index) => (
-            <ToolbarDropdownItem
-              key={lang.code}
-              {...getItemProps({ item: lang.code })}
-              isActive={highlightedIndex === index}
-              isSelected={selectedItem === lang.code}
-            >
-              <MdCheck />
-              {lang.name}
-            </ToolbarDropdownItem>
-          ))}
-      </ToolbarItem>
+  <Container>
+    <ToolbarDropdown id="langFilter" text="Language" selectedItem="eng">
+      {({ getItemProps, selectedItem, highlightedIndex }) =>
+        languages.map((lang, index) => (
+          <ToolbarDropdownItem
+            key={lang.code}
+            {...getItemProps({ item: lang.code })}
+            isActive={highlightedIndex === index}
+            isSelected={selectedItem === lang.code}
+          >
+            <MdCheck />
+            {lang.name}
+          </ToolbarDropdownItem>
+        ))}
+    </ToolbarDropdown>
 
-      <ToolbarItem id="levelFilter" text="Level" selectedItem={null}>
-        {({ getItemProps, highlightedIndex }) =>
-          levels.map((level, index) => (
-            <ToolbarDropdownItem
-              key={level}
-              {...getItemProps({ item: level })}
-              isActive={highlightedIndex === index}
-            >
-              <MdCheck />
-              Level {level}
-            </ToolbarDropdownItem>
-          ))}
-      </ToolbarItem>
-    </Container>
-  </Toolbar>
+    <ToolbarDropdown id="levelFilter" text="Level" selectedItem={null}>
+      {({ getItemProps, highlightedIndex }) =>
+        levels.map((level, index) => (
+          <ToolbarDropdownItem
+            key={level}
+            {...getItemProps({ item: level })}
+            isActive={highlightedIndex === index}
+          >
+            <MdCheck />
+            Level {level}
+          </ToolbarDropdownItem>
+        ))}
+    </ToolbarDropdown>
+  </Container>
 ));


### PR DESCRIPTION
This pull request adds breadcrumb navigation to book pages.

Added a generic layout component that includes breadcrumbs and navbar for all book pages.
Added new routes, so the book page "knows" where it came from, so we can crumb them correctly.

Currently the crumbs are generated in the component it self, and very much tied to the current URLs and book pages. In the future we might want to decouple this a bit, but for now I think it's okay.


This resolves GlobalDigitalLibraryio/issues#105