### PR TITLE
Descriptions in editor's pick overflowed

### DIFF
--- a/components/P.js
+++ b/components/P.js
@@ -13,6 +13,9 @@ import lineHeight from './helpers/lineHeight';
 const P = styled.p`
   ${fontSize};
   ${lineHeight};
+  &:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 export default P;

--- a/components/__tests__/__snapshots__/P.test.js.snap
+++ b/components/__tests__/__snapshots__/P.test.js.snap
@@ -5,6 +5,10 @@ exports[`Responsive font sizes 1`] = `
   font-size: 15px;
 }
 
+.c0:last-child {
+  margin-bottom: 0;
+}
+
 @media screen and (min-width:40em) {
   .c0 {
     font-size: 20px;
@@ -27,6 +31,10 @@ exports[`Responsive font sizes 1`] = `
 exports[`Responsive line heights 1`] = `
 .c0 {
   line-height: 15px;
+}
+
+.c0:last-child {
+  margin-bottom: 0;
 }
 
 @media screen and (min-width:40em) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -118,12 +118,7 @@ class BooksPage extends React.Component<Props> {
       >
         <Meta title={i18n.t`Books`} description={i18n.t`Enjoy all the books`} />
 
-        <Hero
-          colorful
-          h={['237px', '390px']}
-          pt={['15px', '40px']}
-          pb={['42px', '54px']}
-        >
+        <Hero colorful pt={['15px', '40px']} pb={['42px', '54px']}>
           <Container>
             <Link
               route="book"
@@ -131,10 +126,9 @@ class BooksPage extends React.Component<Props> {
             >
               <a>
                 <Card
-                  h={['180px', '295px']}
                   pl={['15px', '20px']}
                   pr={['15px', '80px']}
-                  pt={['15px', '20px']}
+                  py={['15px', '20px']}
                 >
                   <Flex>
                     <BookCover
@@ -148,7 +142,7 @@ class BooksPage extends React.Component<Props> {
                       <H3>
                         <Trans>Editor’s pick</Trans>
                       </H3>
-                      <H4>{editorPick.title}</H4>
+                      <H4 style={{ margin: 0 }}>{editorPick.title}</H4>
                       <P fontSize={[12, 16]} lineHeight={[18, 24]}>
                         {editorPick.description}
                       </P>


### PR DESCRIPTION
Because of the fixed heights for editors picks, sometimes the book
description text would overflow the containing card.

Resolves GlobalDigitalLibraryio/issues#109