### PR TITLE
Functionality for loading more books

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY pages $APP_PATH/pages
 COPY static $APP_PATH/static
 COPY server.js $APP_PATH
 COPY hocs $APP_PATH/hocs
+COPY style $APP_PATH/style
 COPY locale $APP_PATH/locale
 COPY routes.js $APP_PATH
 COPY .babelrc $APP_PATH

--- a/components/helpers/rotate360.js
+++ b/components/helpers/rotate360.js
@@ -1,0 +1,19 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ *
+ * See LICENSE
+ */
+
+import { keyframes } from 'styled-components';
+
+export default keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+`;

--- a/fetch.js
+++ b/fetch.js
@@ -2,7 +2,7 @@
 /**
  * Part of GDL gdl-frontend.
  * Copyright (C) 2017 GDL
- * 
+ *
  * See LICENSE
  */
 
@@ -45,6 +45,7 @@ type Options = {
   pageSize?: number,
   level?: string,
   sort?: 'arrivaldate' | '-arrivaldate' | 'id' | '-id' | 'title' | '-title',
+  page?: number,
 };
 
 export function fetchLevels(
@@ -75,18 +76,26 @@ export function fetchSimilarBooks(
   language: string,
 ): Promise<RemoteData<{ results: Array<Book> }>> {
   return doFetch(
-    `${bookApiUrl}/books/${language}/similar/${id}?sort=-arrivaldate&page-size=${PAGE_SIZE}`,
+    `${bookApiUrl}/books/${language}/similar/${
+      id
+    }?sort=-arrivaldate&page-size=${PAGE_SIZE}`,
   );
 }
 
 export function fetchBooks(
   language: ?string,
   options: Options = {},
-): Promise<RemoteData<{ results: Array<Book> }>> {
+): Promise<
+  RemoteData<{
+    results: Array<Book>,
+    language: Language,
+    page: number,
+    totalCount: number,
+  }>,
+> {
   return doFetch(
-    `${bookApiUrl}/books/${language || ''}?sort=${options.sort ||
-      '-arrivaldate'}&page-size=${options.pageSize || PAGE_SIZE}${options.level
-      ? `&reading-level=${options.level}`
-      : ''}`,
+    `${bookApiUrl}/books/${language || ''}?page=${options.page ||
+      1}&sort=${options.sort || '-arrivaldate'}&page-size=${options.pageSize ||
+      PAGE_SIZE}${options.level ? `&reading-level=${options.level}` : ''}`,
   );
 }

--- a/package.json
+++ b/package.json
@@ -16,15 +16,10 @@
   "lingui": {
     "fallbackLocale": "en",
     "sourceLocale": "en",
-    "srcPathIgnorePatterns": [
-      "/node_modules/",
-      "/.next"
-    ]
+    "srcPathIgnorePatterns": ["/node_modules/", "/.next"]
   },
   "jest": {
-    "setupFiles": [
-      "./jest.setup.js"
-    ]
+    "setupFiles": ["./jest.setup.js"]
   },
   "author": "gdl@knowit.no",
   "license": "GPL-3.0",
@@ -38,7 +33,8 @@
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",
     "i18n:add-locale": "lingui add-locale",
-    "format": "prettier-eslint --write \"components/**/*.js\" \"pages/**/*.js\"",
+    "format":
+      "prettier-eslint --write \"components/**/*.js\" \"pages/**/*.js\" \"hocs/**/*.js\" \"style/**/*.js\"",
     "flow": "flow",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -8,38 +8,117 @@
 
 import * as React from 'react';
 import { Trans } from 'lingui-react';
+import { MdSync } from 'react-icons/lib/md';
+import styled from 'styled-components';
 import { fetchBooks } from '../../fetch';
 import type { Book, RemoteData, Language } from '../../types';
 import defaultPage from '../../hocs/defaultPage';
+import media from '../../components/helpers/media';
 import Layout from '../../components/Layout';
+import Box from '../../components/Box';
 import H1 from '../../components/H1';
 import Container from '../../components/Container';
 import Meta from '../../components/Meta';
 import BookGrid from '../../components/BookGrid';
+import rotate360 from '../../components/helpers/rotate360';
+import theme from '../../style/theme';
+
+const PAGE_SIZE = 30;
 
 type Props = {
   books: RemoteData<{
     results: Array<Book>,
     language: Language,
+    page: number,
+    totalCount: number,
   }>,
-  level: ?string,
+  url: {
+    query: {
+      level?: string,
+      lang: string,
+    },
+  },
 };
 
-class BookPage extends React.Component<Props> {
+type State = {
+  books: {
+    results: Array<Book>,
+    language: Language,
+    page: number,
+    totalCount: number,
+  },
+  isLoadingMore: boolean,
+};
+
+const MoreButton = styled.button`
+  background: transparent;
+  border: none;
+  color: ${theme.colors.link};
+  text-transform: uppercase;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  ${media.tablet`
+    font-size: 14px;
+  `};
+  &[disabled] {
+    cursor: not-allowed;
+    color: ${theme.grays.silverSand};
+  }
+`;
+
+class BookPage extends React.Component<Props, State> {
   static async getInitialProps({ query }) {
     const books = await fetchBooks(query.lang, {
-      pageSize: 25,
+      pageSize: PAGE_SIZE,
       level: query.level,
     });
 
     return {
       books,
-      level: query.level,
     };
   }
 
+  state = {
+    books: this.props.books,
+    isLoadingMore: false,
+  };
+
+  /**
+   * Load more books when demanded
+   */
+  handleLoadMore = async () => {
+    // If it isn't possible to fetch more books. Bail out
+    if (this.state.books.totalCount === this.state.books.results.length) {
+      return;
+    }
+
+    this.setState({ isLoadingMore: true });
+    const { query } = this.props.url;
+
+    const books = await fetchBooks(query.lang, {
+      level: query.level,
+      page: this.state.books.page + 1,
+      pageSize: PAGE_SIZE,
+    });
+
+    this.setState(state => ({
+      isLoadingMore: false,
+      books: {
+        // Set the newly fetched results
+        ...books,
+        // But append the array to the books vi we already have
+        results: state.books.results.concat(books.results),
+      },
+    }));
+  };
+
+  canLoadMore = () =>
+    this.state.books.totalCount > this.state.books.results.length;
+
   render() {
-    const { books, level } = this.props;
+    const { level } = this.props.url.query;
+    const { books } = this.state;
 
     // The route to book differs based on "where we come from". This is because of breadcrumbs
     const route = level
@@ -71,6 +150,21 @@ class BookPage extends React.Component<Props> {
             </H1>
           )}
           <BookGrid books={books.results} route={route} />
+          <Box pt={6} pb={30} textAlign="center">
+            {this.state.isLoadingMore ? (
+              <MdSync
+                style={{ animation: `${rotate360} 2s linear infinite` }}
+              />
+            ) : (
+              <MoreButton
+                disabled={!this.canLoadMore()}
+                onClick={this.handleLoadMore}
+                type="button"
+              >
+                Load more books
+              </MoreButton>
+            )}
+          </Box>
         </Container>
       </Layout>
     );

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -161,7 +161,7 @@ class BookPage extends React.Component<Props, State> {
                 onClick={this.handleLoadMore}
                 type="button"
               >
-                Load more books
+                <Trans>Load more books</Trans>
               </MoreButton>
             )}
           </Box>

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -10,6 +10,7 @@ import * as React from 'react';
 import { Trans } from 'lingui-react';
 import { MdSync } from 'react-icons/lib/md';
 import styled from 'styled-components';
+import SrOnly from '../../components/SrOnly';
 import { fetchBooks } from '../../fetch';
 import type { Book, RemoteData, Language } from '../../types';
 import defaultPage from '../../hocs/defaultPage';
@@ -102,7 +103,7 @@ class BookPage extends React.Component<Props, State> {
       books: {
         // Set the newly fetched results
         ...books,
-        // But append the array to the books vi we already have
+        // But append the array to the books we already have
         results: state.books.results.concat(books.results),
       },
     }));
@@ -145,11 +146,18 @@ class BookPage extends React.Component<Props, State> {
             </H1>
           )}
           <BookGrid books={books.results} route={route} />
-          <Box pt={6} pb={30} textAlign="center">
+          <Box pt={6} pb={30} textAlign="center" aria-live="polite">
             {this.state.isLoadingMore ? (
-              <MdSync
-                style={{ animation: `${rotate360} 2s linear infinite` }}
-              />
+              [
+                <MdSync
+                  key="indicator"
+                  aria-hidden
+                  style={{ animation: `${rotate360} 2s linear infinite` }}
+                />,
+                <SrOnly key="sr">
+                  <Trans>Loading books</Trans>
+                </SrOnly>,
+              ]
             ) : (
               <MoreButton
                 disabled={!this.canLoadMore()}

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -88,11 +88,6 @@ class BookPage extends React.Component<Props, State> {
    * Load more books when demanded
    */
   handleLoadMore = async () => {
-    // If it isn't possible to fetch more books. Bail out
-    if (this.state.books.totalCount === this.state.books.results.length) {
-      return;
-    }
-
     this.setState({ isLoadingMore: true });
     const { query } = this.props.url;
 

--- a/style/theme.js
+++ b/style/theme.js
@@ -1,0 +1,41 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ *
+ * See LICENSE
+ */
+
+// TODO: Move all colors into the colors object
+const theme = {
+  colors: {
+    link: '#1566b6',
+    white: '#fff',
+    dark: '#444',
+  },
+  primaries: {
+    primary: '#20588f',
+    secondary: '#507aa4',
+    tertiary: '#a5bcd3',
+    light: '#ceddea',
+    highlight: '#edf7ff',
+    dark: '#184673',
+  },
+  supports: {
+    greenPrimary: '#5cbc80',
+    greenHighlight: '#edfff4',
+    greenDark: '#359258',
+  },
+  grays: {
+    dark: '#444',
+    white: '#fff',
+    steel: '#666',
+    jumbo: '#888',
+    silverSand: '#bbb',
+    platinum: '#e3e3e3',
+    gallery: '#eff0f2',
+    desertStorm: '#f8f8f8',
+  },
+};
+
+export default theme;


### PR DESCRIPTION
Add a "load more books" to the bottom of the books page.

When clicked a loading indicator is displayed while more books are fetched and appended to the book grid.

This resolves GlobalDigitalLibraryio/issues#117