### PR TITLE
Add polyfills for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,15 @@
       "presets": ["next/babel", "lingui-react"]
     },
     "production": {
-      "presets": ["next/babel", "lingui-react"]
+      "presets": [
+        [
+          "next/babel",
+          {
+            "preset-env": { "targets": { "ie": 11 } }
+          }
+        ],
+        "lingui-react"
+      ]
     },
     "test": {
       "presets": [

--- a/__tests__/pages/_document.test.js
+++ b/__tests__/pages/_document.test.js
@@ -12,8 +12,10 @@ import Document from '../../pages/_document';
 
 test('Sets global GDL environment variable, defaults to \'test\'', () => {
   const tree = shallow(<Document />);
-  expect(tree.find('script').html()).toEqual(
-    '<script>window.__GDL_ENVIRONMENT__ = \'test\';</script>',
-  );
+  expect(
+    tree
+      .find('script')
+      .first()
+      .html()
+  ).toEqual('<script>window.__GDL_ENVIRONMENT__ = \'test\';</script>');
 });
-

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,13 +12,10 @@ import { ServerStyleSheet, injectGlobal } from 'styled-components';
 import globalStyles from '../style/globalStyles';
 import config from '../config';
 
-
-
 // eslint-disable-next-line no-unused-expressions
 injectGlobal`
   ${globalStyles}
 `;
-
 
 /**
  * We cheat a bit and add next-head to a couple of the tags, so we can ovveride them later if needed
@@ -28,7 +25,7 @@ export default class GDLDocument extends Document {
     const sheet = new ServerStyleSheet();
 
     const page = renderPage(App => props =>
-      sheet.collectStyles(<App {...props} />),
+      sheet.collectStyles(<App {...props} />)
     );
 
     const styleTags = sheet.getStyleElement();
@@ -37,7 +34,7 @@ export default class GDLDocument extends Document {
       ...page,
       language: req.language,
       styleTags,
-      url: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
+      url: `${req.protocol}://${req.get('host')}${req.originalUrl}`
     };
   }
 
@@ -49,9 +46,25 @@ export default class GDLDocument extends Document {
         <Head>
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          {/* IE automatically looks for  browserconfig.xml in the root directory of the server if this is not explictly turned off */}
+          <meta name="msapplication-config" content="none" />
           {/* Adding next-head to the following meta tag ensures it gets deduped properly on the client in our own Head component */}
-          <meta property="og:url" content={this.props.url} className="next-head" />
-          <script dangerouslySetInnerHTML={{ __html: `window.${config.GLOBAL_VAR_NAME} = '${process.env.GDL_ENVIRONMENT || 'test'}';` }} />
+          <meta
+            property="og:url"
+            content={this.props.url}
+            className="next-head"
+          />
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.${config.GLOBAL_VAR_NAME} = '${process.env
+                .GDL_ENVIRONMENT || 'test'}';`
+            }}
+          />
+          <script
+            src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign,String.prototype.includes"
+            defer
+            async
+          />
           {this.props.styleTags}
         </Head>
         <body>


### PR DESCRIPTION
To use the site in IE11, we need polyfills for Object.assign and String.includes, so we add these explitcly using polyfill.io.

This makes the site usable, meaning you can actually read books. There are still a few minor layout issues. But I think we should push that to a later date because of the tiny market share.

This resolves GlobalDigitalLibraryio/issues#164