### PR TITLE
Update component state when new books are fetched

### DIFF
--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -65,6 +65,12 @@ class BookPage extends React.Component<Props, State> {
     isLoadingMore: false
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.books !== this.props.books) {
+      this.setState({ books: nextProps.books });
+    }
+  }
+
   /**
    * Load more books when demanded
    */


### PR DESCRIPTION
When navigating different levels, the books weren't updated because we
didn't set a new state when receving updates props

This fixes GlobalDigitalLibraryio/issues#178