### PR TITLE
Use babel-plugin to add hash query param to static assets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -23,6 +23,14 @@
     }
   },
   "plugins": [
+    [
+      "transform-assets",
+      {
+        "extensions": ["png", "jpg"],
+        "regExp": ".*/static/(.+)",
+        "name": "/static/[1]?[sha512:hash:base64:7]"
+      }
+    ],
     "polished",
     "transform-flow-strip-types",
     "inline-react-svg",

--- a/components/AboutFooter.js
+++ b/components/AboutFooter.js
@@ -12,6 +12,16 @@ import Hero from './Hero';
 import Container from './Container';
 import Flex from './Flex';
 
+const allChildrenPNG = require('../static/footer/all-children.png');
+const australianAidPNG = require('../static/footer/australian-aid.png');
+const noradPNG = require('../static/footer/norad.png');
+const usaidPNG = require('../static/footer/usaid.png');
+const ndlaPNG = require('../static/footer/ndla.png');
+const facebookPNG = require('../static/footer/facebook.png');
+const twitterPNG = require('../static/footer/twitter.png');
+const emailPNG = require('../static/footer/mail.png');
+const worldvisionPNG = require('../static/footer/world-vision.png');
+
 const PartnerImg = styled.img`
   object-fit: scale-down;
   height: 40px;
@@ -42,7 +52,7 @@ const Footer = () => (
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img src="/static/footer/facebook.png" alt="GDL on Facebook" />
+          <img src={facebookPNG} alt="GDL on Facebook" />
         </SocialLink>
         <SocialLink
           id="twitter"
@@ -50,10 +60,10 @@ const Footer = () => (
           target="_blank"
           rel="noopener noreferrer"
         >
-          <img src="/static/footer/twitter.png" alt="GDL on Twitter" />
+          <img src={twitterPNG} alt="GDL on Twitter" />
         </SocialLink>
         <SocialLink href="mailto:christer@digitallibrary.io">
-          <img src="/static/footer/mail.png" alt="Send us an e-mail" />
+          <img src={emailPNG} alt="Send us an e-mail" />
         </SocialLink>
       </Flex>
     </Container>
@@ -61,29 +71,20 @@ const Footer = () => (
       <Container py={32} mw={1075}>
         <Flex justify="space-between" wrap>
           <a href="https://allchildrenreading.org/">
-            <PartnerImg
-              src="/static/footer/all-children.png"
-              alt="All Children Reading"
-            />
+            <PartnerImg src={allChildrenPNG} alt="All Children Reading" />
           </a>
           <a href="https://www.usaid.gov/">
-            <PartnerImg src="/static/footer/usaid.png" alt="USAID" />
+            <PartnerImg src={usaidPNG} alt="USAID" />
           </a>
           <a href="https://www.worldvision.org/">
-            <PartnerImg
-              src="/static/footer/world-vision.png"
-              alt="World Vision"
-            />
+            <PartnerImg src={worldvisionPNG} alt="World Vision" />
           </a>
-          <PartnerImg
-            src="/static/footer/australian-aid.png"
-            alt="Australian Aid"
-          />
+          <PartnerImg src={australianAidPNG} alt="Australian Aid" />
           <a href="https://norad.no/en/front/">
-            <PartnerImg src="/static/footer/norad.png" alt="NORAD" />
+            <PartnerImg src={noradPNG} alt="NORAD" />
           </a>
           <a href="https://ndla.no/">
-            <PartnerImg src="/static/footer/ndla.png" alt="NDLA" />
+            <PartnerImg src={ndlaPNG} alt="NDLA" />
           </a>
         </Flex>
       </Container>

--- a/components/CoverImage.js
+++ b/components/CoverImage.js
@@ -9,7 +9,7 @@
 import * as React from 'react';
 import Image from './Image';
 
-const NO_COVER_PLACEHOLDER_URL = '/static/placeholder-cover.png';
+const NO_COVER_PLACEHOLDER_URL = require('../static/placeholder-cover.png');
 
 /**
  * Add query parameters to book cover images so they fit our wanted ratio

--- a/package.json
+++ b/package.json
@@ -16,15 +16,10 @@
   "lingui": {
     "fallbackLocale": "en",
     "sourceLocale": "en",
-    "srcPathIgnorePatterns": [
-      "/node_modules/",
-      "/.next"
-    ]
+    "srcPathIgnorePatterns": ["/node_modules/", "/.next"]
   },
   "jest": {
-    "setupFiles": [
-      "./jest.setup.js"
-    ]
+    "setupFiles": ["./jest.setup.js"]
   },
   "author": "gdl@knowit.no",
   "license": "GPL-3.0",
@@ -38,7 +33,8 @@
     "i18n:extract": "lingui extract",
     "i18n:compile": "lingui compile",
     "i18n:add-locale": "lingui add-locale",
-    "format": "prettier-eslint --write \"components/**/*.js\" \"server/**/*.js\" \"pages/**/*.js\" \"hocs/**/*.js\" \"style/**/*.js\" \"lib/**/*.js\"",
+    "format":
+      "prettier-eslint --write \"components/**/*.js\" \"server/**/*.js\" \"pages/**/*.js\" \"hocs/**/*.js\" \"style/**/*.js\" \"lib/**/*.js\"",
     "flow": "flow",
     "storybook": "start-storybook -p 9001 -c .storybook"
   },
@@ -78,6 +74,7 @@
     "babel-plugin-emotion": "9.0.0-1",
     "babel-plugin-inline-react-svg": "0.5.2",
     "babel-plugin-polished": "1.1.0",
+    "babel-plugin-transform-assets": "0.2.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "babel-preset-lingui-react": "1.0.13",
     "enzyme": "3.3.0",

--- a/pages/about.js
+++ b/pages/about.js
@@ -27,7 +27,7 @@ import media from '../style/media';
 const childrenJPG = require('../static/about/children-306607.jpg');
 const playingJPG = require('../static/about/kids-playing.jpg');
 const readingJPG = require('../static/about/boy-reading.jpg');
-const iconsPNG = require('../static/about/books.png');
+const booksPNG = require('../static/about/books.png');
 
 const CardImg = styled.img`
   width: 100%;
@@ -37,7 +37,7 @@ const CardImg = styled.img`
 
 export const HeroWithIcons = styled(Hero)`
   color: #fff;
-  background: url('${iconsPNG}'),
+  background: url('${booksPNG}'),
     linear-gradient(135deg, #004b91 0%, #5abc7f 100%);
 `;
 

--- a/pages/about.js
+++ b/pages/about.js
@@ -24,6 +24,11 @@ import Hero from '../components/Hero';
 import theme from '../style/theme';
 import media from '../style/media';
 
+const childrenJPG = require('../static/about/children-306607.jpg');
+const playingJPG = require('../static/about/kids-playing.jpg');
+const readingJPG = require('../static/about/boy-reading.jpg');
+const iconsPNG = require('../static/about/books.png');
+
 const CardImg = styled.img`
   width: 100%;
   height: 100%;
@@ -32,7 +37,7 @@ const CardImg = styled.img`
 
 export const HeroWithIcons = styled(Hero)`
   color: #fff;
-  background: url('/static/about/books.png'),
+  background: url('${iconsPNG}'),
     linear-gradient(135deg, #004b91 0%, #5abc7f 100%);
 `;
 
@@ -99,17 +104,14 @@ const About = () => (
             </Link>
           </Box>
           <Box w={[1, 0.5]}>
-            <CardImg
-              src="/static/about/children-306607.jpg"
-              alt="Girl reading"
-            />
+            <CardImg src={childrenJPG} alt="Girl reading" />
           </Box>
         </Flex>
       </Card>
       <Card my={60}>
         <Flex wrap={[true, false]}>
           <Box w={[1, 0.5]}>
-            <CardImg src="/static/about/kids-playing.jpg" alt="Kids playing" />
+            <CardImg src={playingJPG} alt="Kids playing" />
           </Box>
           <Box w={[1, 0.5]} py={10} px={30}>
             <H3>Compilation of digital libraries</H3>
@@ -149,7 +151,7 @@ const About = () => (
             </A>
           </Box>
           <Box w={[1, 0.5]}>
-            <CardImg src="/static/about/boy-reading.jpg" alt="Boy reading" />
+            <CardImg src={readingJPG} alt="Boy reading" />
           </Box>
         </Flex>
       </Card>

--- a/pages/books/_book.js
+++ b/pages/books/_book.js
@@ -32,6 +32,8 @@ import BookList from '../../components/BookList';
 import media from '../../style/media';
 import { flexColumnCentered } from '../../style/flex';
 
+const iconsPNG = require('../../static/about/icons.png');
+
 type Props = {
   book: RemoteData<Book>,
   similar: RemoteData<{
@@ -60,9 +62,8 @@ const HeroCard = styled(Card)`
   ${flexColumnCentered};
 `;
 
-// TODO: Replace background image
 const Hero = styled('div')`
-  background-image: url(/static/about/icons.png);
+  background-image: url(${iconsPNG});
   background-size: contain;
 `;
 

--- a/pages/books/_book.js
+++ b/pages/books/_book.js
@@ -63,7 +63,7 @@ const HeroCard = styled(Card)`
 `;
 
 const Hero = styled('div')`
-  background-image: url(${iconsPNG});
+  background-image: url('${iconsPNG}');
   background-size: contain;
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,6 +591,14 @@ assertion-error@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
 
+asset-require-hook@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/asset-require-hook/-/asset-require-hook-1.2.0.tgz#dd4b8f7c187774223ec31e30bd93aa875d174c6e"
+  dependencies:
+    loader-utils "^0.2.12"
+    lodash.assign "^4.0.0"
+    mime "^1.3.4"
+
 ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -1132,6 +1140,12 @@ babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-assets@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-assets/-/babel-plugin-transform-assets-0.2.0.tgz#67dea3ef3a21aa933aa23d74074015ed9d4aa06c"
+  dependencies:
+    asset-require-hook "^1.0.2"
 
 babel-plugin-transform-async-generator-functions@^6.24.1:
   version "6.24.1"
@@ -5509,6 +5523,15 @@ loader-utils@1.1.0, loader-utils@^1.0.2, loader-utils@^1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
+loader-utils@^0.2.12:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -5562,6 +5585,10 @@ lodash.assign@^3.0.0:
     lodash._baseassign "^3.0.0"
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
+
+lodash.assign@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash.camelcase@^4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Added babel-plugin [transform-assets](https://github.com/jmurzy/babel-plugin-transform-assets/issues) that allows us to require our static assets as URLs with a hash of the asset as a query parameter to the URL.

The result is something like this:
```
<!-- before -->
<img src="static/about/boy-reading.jpg" />

<!-- after -->
<img src="static/about/boy-reading.jpg?2TYaWEv" />
```

With the hash as part of the URL, we have an excellent cache busting mechanism, allowing us to cache the assets indefinitely on the client in the future (the caching itself is not a part of this commit).

Bonus: Since we now import the assets via `require`,  both eslint and Flow throws a fit if it is unable to find the file. Way nicer than just having string constants referring to our assets, which could be broken at build time without us knowing.
 
This resolves GlobalDigitalLibraryio/issues#180