### PR TITLE
Remove client side session tokens

### DIFF
--- a/components/Reader/Reader.js
+++ b/components/Reader/Reader.js
@@ -8,7 +8,7 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import Swipeable from 'react-swipeable';
-import fetchWithToken from '../../fetch';
+import doFetch from '../../fetch';
 import Box from '../Box';
 import type { Book, Chapter } from '../../types';
 import Backdrop from './Backdrop';
@@ -41,18 +41,18 @@ type ReaderProps = {
   chapter: ?Chapter,
   chapterNumber: number,
   onRequestNext(): void,
-  onRequestPrevious(): void,
+  onRequestPrevious(): void
 };
 
 type ReaderState = {
-  showOverlay: boolean,
+  showOverlay: boolean
 };
 
 const OVERLAY_TIMEOUT = 3000; // 3 seconds
 
 class Reader extends React.PureComponent<ReaderProps, ReaderState> {
   state = {
-    showOverlay: false,
+    showOverlay: false
   };
 
   componentWillUnmount() {
@@ -75,12 +75,12 @@ class Reader extends React.PureComponent<ReaderProps, ReaderState> {
         if (this.state.showOverlay) {
           this.timerId = window.setTimeout(
             () => this.setState({ showOverlay: false }),
-            OVERLAY_TIMEOUT,
+            OVERLAY_TIMEOUT
           );
         } else {
           window.clearTimeout(this.timerId);
         }
-      },
+      }
     );
   };
 
@@ -140,17 +140,17 @@ class Reader extends React.PureComponent<ReaderProps, ReaderState> {
 
 type ReaderContainerState = {
   chapters: { [number]: Chapter },
-  chapter: number,
+  chapter: number
 };
 
 type ReaderContainerProps = {
   book: Book,
-  initialChapter: ?string,
+  initialChapter: ?string
 };
 
 export default class ReaderContainer extends React.Component<
   ReaderContainerProps,
-  ReaderContainerState,
+  ReaderContainerState
 > {
   constructor(props: ReaderContainerProps) {
     super(props);
@@ -163,7 +163,7 @@ export default class ReaderContainer extends React.Component<
 
     this.state = {
       chapters: {},
-      chapter: initialChapter,
+      chapter: initialChapter
     };
   }
 
@@ -178,7 +178,7 @@ export default class ReaderContainer extends React.Component<
   onRequestClose = () => {
     Router.replaceRoute('book', {
       id: this.props.book.id,
-      lang: this.props.book.language.code,
+      lang: this.props.book.language.code
     });
   };
 
@@ -188,7 +188,7 @@ export default class ReaderContainer extends React.Component<
       this.loadChapter(this.state.chapter + 2);
       this.setState(
         state => ({ chapter: state.chapter + 1 }),
-        this.changeChapterInUrl,
+        this.changeChapterInUrl
       );
     }
   };
@@ -199,7 +199,7 @@ export default class ReaderContainer extends React.Component<
       this.loadChapter(this.state.chapter - 2);
       this.setState(
         state => ({ chapter: state.chapter - 1 }),
-        this.changeChapterInUrl,
+        this.changeChapterInUrl
       );
     }
   };
@@ -210,9 +210,9 @@ export default class ReaderContainer extends React.Component<
       {
         id: this.props.book.id,
         lang: this.props.book.language.code,
-        chapter: this.state.chapter,
+        chapter: this.state.chapter
       },
-      { shallow: true },
+      { shallow: true }
     );
 
   async loadChapter(chapterNumber: number) {
@@ -225,15 +225,13 @@ export default class ReaderContainer extends React.Component<
     const maybeChapter = this.state.chapters[chapterNumber];
 
     if (!maybeChapter && this.props.book.chapters[chapterIndex]) {
-      const chapter = await fetchWithToken(
-        this.props.book.chapters[chapterIndex].url,
-      )();
+      const chapter = await doFetch(this.props.book.chapters[chapterIndex].url);
 
       this.setState((state: ReaderContainerState) => ({
         chapters: {
           ...state.chapters,
-          [chapterNumber]: chapter,
-        },
+          [chapterNumber]: chapter
+        }
       }));
     }
   }

--- a/components/Sidemenu/Sidemenu.js
+++ b/components/Sidemenu/Sidemenu.js
@@ -97,8 +97,8 @@ class Sidebar extends React.Component<Props, State> {
 
   getMenuData = async () => {
     const [languages, levels] = await Promise.all([
-      fetchLanguages()(),
-      fetchLevels(this.props.language.code)()
+      fetchLanguages(),
+      fetchLevels(this.props.language.code)
     ]);
 
     this.setState({

--- a/fetch.js
+++ b/fetch.js
@@ -16,7 +16,7 @@ import type {
   Translation
 } from './types';
 import { bookApiUrl } from './config';
-import { getSessionToken, getPersonalToken } from './lib/auth/token';
+import { getSsrToken, getPersonalToken } from './lib/auth/token';
 
 /*
 * Wrap fetch with some error handling and automatic json parsing
@@ -28,7 +28,7 @@ async function doFetch(
     method: 'POST' | 'GET',
     body: ?any
   },
-  token: ?string = getSessionToken()
+  token: ?string = getSsrToken()
 ): Promise<RemoteData<any>> {
   try {
     const response = await fetch(url, {

--- a/fetch.js
+++ b/fetch.js
@@ -15,89 +15,56 @@ import type {
   Translation
 } from './types';
 import { bookApiUrl } from './config';
-import { getAccessTokenFromLocalStorage, setAnonToken } from './lib/auth/token';
-
-let getTokenOnServer;
-
-if (!process.browser) {
-  getTokenOnServer = require('./server/lib/auth').getToken; // eslint-disable-line global-require
-}
-
-/**
- * Get anonymous access token
- */
-export async function fetchAnonToken(): Promise<{
-  access_token: string,
-  expires_in: number
-}> {
-  if (!process.browser) {
-    const token = await getTokenOnServer();
-    return token;
-  }
-  const response = await fetch('/get_token');
-  if (response.ok) {
-    const token = await response.json();
-    return token;
-  }
-  throw new Error('Unable to get access token');
-}
+import { getAccessTokenFromLocalStorage } from './lib/auth/token';
 
 /*
 * Wrap fetch with some error handling and automatic json parsing
 * Also ensures we have a valid access token.
 */
-function fetchWithToken(
+async function doFetch(
   url: string,
   options: ?{
     method: 'POST' | 'GET',
     body: ?any
   }
-): (accessToken: ?string) => Promise<RemoteData<any>> {
-  return async (accessToken: ?string) => {
-    if (!process.browser && !accessToken) {
-      throw new Error(
-        'accessToken is a required parameter when calling fetch on the server'
-      );
-    }
+): Promise<RemoteData<any>> {
+  const token = process.browser ? getAccessTokenFromLocalStorage() : null;
 
-    let token = accessToken || getAccessTokenFromLocalStorage();
-
-    try {
-      // Automatically renew token on the client if it is expired
-      if (process.browser && token == null) {
+  try {
+    // Automatically renew token on the client if it is expired
+    /* if (process.browser && token == null) {
         const fullToken = await fetchAnonToken();
         setAnonToken(fullToken);
         token = fullToken.access_token;
-      }
+      } */
 
-      const response = await fetch(url, {
-        headers: {
-          Authorization: token ? `Bearer ${token}` : null
-        },
-        ...options
-      });
+    const response = await fetch(url, {
+      headers: {
+        Authorization: token ? `Bearer ${token}` : null
+      },
+      ...options
+    });
 
-      if (response.headers.get('Content-Type').includes('application/json')) {
-        const json = await response.json();
-        // Check if the response is in the 200-299 range
-        if (response.ok) {
-          return json;
-        }
+    if (response.headers.get('Content-Type').includes('application/json')) {
+      const json = await response.json();
+      // Check if the response is in the 200-299 range
+      if (response.ok) {
+        return json;
       }
-      const err = new Error('Remote data error');
-      // $FlowFixMe Ignore the flow error here. Should really extend the Error class, but that requires special Babel configuration. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
-      err.statusCode = response.status || 500;
-      throw err;
-    } catch (error) {
-      if (!error.statusCode) {
-        error.statusCode = 500;
-      }
-      throw error;
     }
-  };
+    const err = new Error('Remote data error');
+    // $FlowFixMe Ignore the flow error here. Should really extend the Error class, but that requires special Babel configuration. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types
+    err.statusCode = response.status || 500;
+    throw err;
+  } catch (error) {
+    if (!error.statusCode) {
+      error.statusCode = 500;
+    }
+    throw error;
+  }
 }
 
-export default fetchWithToken;
+export default doFetch;
 
 // Default page size
 const PAGE_SIZE = 5;
@@ -111,48 +78,40 @@ type Options = {
 
 export function fetchLevels(
   language: ?string
-): (accessToken: ?string) => Promise<RemoteData<Array<string>>> {
-  return accessToken =>
-    fetchWithToken(`${bookApiUrl}/levels/${language || ''}`)(accessToken);
+): Promise<RemoteData<Array<string>>> {
+  return doFetch(`${bookApiUrl}/levels/${language || ''}`);
 }
 
-export function fetchLanguages(): (
-  accessToken: ?string
-) => Promise<RemoteData<Array<Language>>> {
-  return accessToken => fetchWithToken(`${bookApiUrl}/languages`)(accessToken);
+export function fetchLanguages(): Promise<RemoteData<Array<Language>>> {
+  return doFetch(`${bookApiUrl}/languages`);
 }
 
 export function fetchFeaturedContent(
   language: ?string
-): (accessToken: ?string) => Promise<RemoteData<Array<FeaturedContent>>> {
-  return accessToken =>
-    fetchWithToken(`${bookApiUrl}/featured/${language || ''}`)(accessToken);
+): Promise<RemoteData<Array<FeaturedContent>>> {
+  return doFetch(`${bookApiUrl}/featured/${language || ''}`);
 }
 
 export function fetchBook(
   id: string | number,
   language: string
-): (accessToken: ?string) => Promise<RemoteData<Book>> {
-  return accessToken =>
-    fetchWithToken(`${bookApiUrl}/books/${language}/${id}`)(accessToken);
+): Promise<RemoteData<Book>> {
+  return doFetch(`${bookApiUrl}/books/${language}/${id}`);
 }
 
 export function fetchSimilarBooks(
   id: string | number,
   language: string
-): (accessToken: ?string) => Promise<RemoteData<{ results: Array<Book> }>> {
-  return accessToken =>
-    fetchWithToken(
-      `${bookApiUrl}/books/${language}/similar/${id}?sort=-arrivaldate&page-size=${PAGE_SIZE}`
-    )(accessToken);
+): Promise<RemoteData<{ results: Array<Book> }>> {
+  return doFetch(
+    `${bookApiUrl}/books/${language}/similar/${id}?sort=-arrivaldate&page-size=${PAGE_SIZE}`
+  );
 }
 
 export function fetchBooks(
   language: ?string,
   options: Options = {}
-): (
-  accessToken: ?string
-) => Promise<
+): Promise<
   RemoteData<{
     results: Array<Book>,
     language: Language,
@@ -160,29 +119,21 @@ export function fetchBooks(
     totalCount: number
   }>
 > {
-  return accessToken =>
-    fetchWithToken(
-      `${bookApiUrl}/books/${language || ''}?page=${options.page ||
-        1}&sort=${options.sort ||
-        '-arrivaldate'}&page-size=${options.pageSize || PAGE_SIZE}${
-        options.level ? `&reading-level=${options.level}` : ''
-      }`
-    )(accessToken);
+  return doFetch(
+    `${bookApiUrl}/books/${language || ''}?page=${options.page ||
+      1}&sort=${options.sort || '-arrivaldate'}&page-size=${options.pageSize ||
+      PAGE_SIZE}${options.level ? `&reading-level=${options.level}` : ''}`
+  );
 }
 
-export function fetchSupportedLanguages(): (
-  acccessToken: ?string
-) => Promise<RemoteData<Array<Language>>> {
-  return accessToken =>
-    fetchWithToken(`${bookApiUrl}/translations/supported-languages`)(
-      accessToken
-    );
+export function fetchSupportedLanguages(): Promise<
+  RemoteData<Array<Language>>
+> {
+  return doFetch(`${bookApiUrl}/translations/supported-languages`);
 }
 
-export function fetchMyTranslations(): (
-  acccessToken: ?string
-) => Promise<RemoteData<Array<Book>>> {
-  return accessToken => fetchWithToken(`${bookApiUrl}/books/mine`)(accessToken);
+export function fetchMyTranslations(): Promise<RemoteData<Array<Book>>> {
+  return doFetch(`${bookApiUrl}/books/mine`);
 }
 
 export function sendToTranslation(
@@ -190,8 +141,8 @@ export function sendToTranslation(
   fromLanguage: string,
   toLanguage: string
 ): Promise<RemoteData<Translation>> {
-  return fetchWithToken(`${bookApiUrl}/translations`, {
+  return doFetch(`${bookApiUrl}/translations`, {
     method: 'POST',
     body: JSON.stringify({ bookId, fromLanguage, toLanguage })
-  })();
+  });
 }

--- a/fetch.js
+++ b/fetch.js
@@ -15,7 +15,7 @@ import type {
   Translation
 } from './types';
 import { bookApiUrl } from './config';
-import { getAccessTokenFromLocalStorage } from './lib/auth/token';
+import { getSessionToken } from './lib/auth/token';
 
 /*
 * Wrap fetch with some error handling and automatic json parsing
@@ -28,16 +28,9 @@ async function doFetch(
     body: ?any
   }
 ): Promise<RemoteData<any>> {
-  const token = process.browser ? getAccessTokenFromLocalStorage() : null;
+  const token = getSessionToken();
 
   try {
-    // Automatically renew token on the client if it is expired
-    /* if (process.browser && token == null) {
-        const fullToken = await fetchAnonToken();
-        setAnonToken(fullToken);
-        token = fullToken.access_token;
-      } */
-
     const response = await fetch(url, {
       headers: {
         Authorization: token ? `Bearer ${token}` : null

--- a/hocs/defaultPage.js
+++ b/hocs/defaultPage.js
@@ -13,7 +13,7 @@ import withI18n from './withI18n';
 import withTheme from './withTheme';
 import withErrorBoundary from './withErrorBoundary';
 import type { Context } from '../types';
-import { getPersonalToken, LOGOUT_KEY } from '../lib/auth/token';
+import { LOGOUT_KEY } from '../lib/auth/token';
 import logPageView from '../lib/analytics';
 
 logPageView();
@@ -27,28 +27,14 @@ if (typeof window !== 'undefined' && window.__NEXT_DATA__) {
 
 /**
  * HoC that combines all necessary pages wrapper so we get a single point of entry
- * It also makes sure we have a token to the APIs
  */
 
 const defaultPage = Page =>
   class DefaultPage extends React.Component<any> {
-    static async getInitialProps(ctx: Context) {
-      const personalToken = getPersonalToken(ctx.req);
-      const isAuthenticated = Boolean(personalToken);
-
-      ctx.isAuthenticated = isAuthenticated;
-
-      // Evaluate the composed component's getInitialProps()
-      let composedInitialProps;
-      // Check if it actually is a next page
-      if (typeof Page.getInitialProps === 'function') {
-        composedInitialProps = await Page.getInitialProps(ctx);
-      }
-
-      return {
-        isAuthenticated,
-        ...composedInitialProps
-      };
+    static getInitialProps(ctx: Context) {
+      return (
+        typeof Page.getInitialProps === 'function' && Page.getInitialProps(ctx)
+      );
     }
 
     componentDidMount() {

--- a/hocs/defaultPage.js
+++ b/hocs/defaultPage.js
@@ -13,7 +13,7 @@ import withI18n from './withI18n';
 import withTheme from './withTheme';
 import withErrorBoundary from './withErrorBoundary';
 import type { Context } from '../types';
-import { getAuthToken, LOGOUT_KEY } from '../lib/auth/token';
+import { getPersonalToken, LOGOUT_KEY } from '../lib/auth/token';
 import logPageView from '../lib/analytics';
 
 logPageView();
@@ -33,7 +33,7 @@ if (typeof window !== 'undefined' && window.__NEXT_DATA__) {
 const defaultPage = Page =>
   class DefaultPage extends React.Component<any> {
     static async getInitialProps(ctx: Context) {
-      const personalToken = getAuthToken(ctx.req);
+      const personalToken = getPersonalToken(ctx.req);
       const isAuthenticated = Boolean(personalToken);
 
       ctx.isAuthenticated = isAuthenticated;

--- a/hocs/securePage.js
+++ b/hocs/securePage.js
@@ -10,6 +10,7 @@ import * as React from 'react';
 import Link from 'next/link';
 import type { Context } from '../types';
 import defaultPage from './defaultPage';
+import { getPersonalToken } from '../lib/auth/token';
 import Layout from '../components/Layout';
 import Container from '../components/Container';
 
@@ -18,10 +19,21 @@ import Container from '../components/Container';
  */
 const securePageHoc = Page =>
   class SecurePage extends React.Component<any> {
-    static getInitialProps(ctx: Context) {
-      return (
-        typeof Page.getInitialProps === 'function' && Page.getInitialProps(ctx)
-      );
+    static async getInitialProps(ctx: Context) {
+      const personalToken = getPersonalToken(ctx.req);
+      const isAuthenticated = Boolean(personalToken);
+
+      // Evaluate the composed component's getInitialProps()
+      let composedInitialProps;
+      // Check if it actually is a next page
+      if (typeof Page.getInitialProps === 'function') {
+        composedInitialProps = await Page.getInitialProps(ctx);
+      }
+
+      return {
+        isAuthenticated,
+        ...composedInitialProps
+      };
     }
 
     render() {

--- a/lib/auth/constants.js
+++ b/lib/auth/constants.js
@@ -1,0 +1,11 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 GDL
+ *
+ * See LICENSE
+ */
+
+module.exports = {
+  RATE_LIMIT_TOKEN_GLOBAL_VAR: 'apiAccessToken'
+};

--- a/lib/auth/token.js
+++ b/lib/auth/token.js
@@ -7,76 +7,44 @@
  */
 
 import Cookie from 'js-cookie';
-import lscache from 'lscache';
-import type { $Request, $Response } from 'express';
+import type { $Request } from 'express';
 
-const ANON_ACCESS_TOKEN_KEY = 'anon-access-token';
-const AUTH_ACCESS_TOKEN_KEY = 'auth-access-token';
+const SESSION_TOKEN_KEY = 'session';
+const PERSONAL_TOKEN_KEY = 'personal-session';
 export const LOGOUT_KEY = 'logout';
 
 // Returns a date with time = now() + number of seconds
 const expirationDate = (seconds: number) =>
   new Date(seconds * 1000 + new Date().getTime());
-const secondsToMinutes = (seconds: number) => Math.floor(seconds / 60);
 
 /**
- * Set anonymous tokens (for user not logged in)
+ * Set personal tokens (for user logging in)
  */
-export function setAnonToken(token: {
-  access_token: string,
-  expires_in: number
-}) {
-  if (!process.browser || token.access_token == null) {
-    return;
-  }
-
-  // lscache uses minutes for expiration, while the token TTL is in seconds
-  lscache.set(
-    ANON_ACCESS_TOKEN_KEY,
-    token.access_token,
-    secondsToMinutes(token.expires_in)
-  );
-  Cookie.set(ANON_ACCESS_TOKEN_KEY, token.access_token, {
-    expires: expirationDate(token.expires_in)
-  });
-}
-
-/**
- * Set auth tokens (for user logging in)
- */
-export function setAuthToken(token: {
+export function setPersonalToken(token: {
   accessToken: string,
   expiresIn: number
 }) {
   if (!process.browser || token.accessToken == null) {
     return;
   }
-  // lscache uses minutes for expiration, while the token TTL is in seconds
-  lscache.set(
-    AUTH_ACCESS_TOKEN_KEY,
-    token.accessToken,
-    secondsToMinutes(token.expiresIn)
-  );
-  Cookie.set(AUTH_ACCESS_TOKEN_KEY, token.accessToken, {
+  Cookie.set(PERSONAL_TOKEN_KEY, token.accessToken, {
     expires: expirationDate(token.expiresIn)
   });
-
-  // Finally, clear any anonomyous token
-  lscache.remove(ANON_ACCESS_TOKEN_KEY);
-  Cookie.remove(ANON_ACCESS_TOKEN_KEY);
 }
 
-export function unsetAuthToken() {
+export function unsetPersonalToken() {
   if (!process.browser) {
     return;
   }
-  lscache.remove(AUTH_ACCESS_TOKEN_KEY);
-  Cookie.remove(AUTH_ACCESS_TOKEN_KEY);
+  Cookie.remove(PERSONAL_TOKEN_KEY);
 
   // Listen on this in defaultPage HoC. Triggers logout in every tab if multiple tabs are open
   window.localStorage.setItem(LOGOUT_KEY, Date.now());
 }
 
+/**
+ * Small util function that gets cookie value by name from the request object
+ */
 function getCookie(name: string, req: $Request): ?string {
   if (!req.headers.cookie) {
     return undefined;
@@ -86,32 +54,17 @@ function getCookie(name: string, req: $Request): ?string {
   return v ? v[2] : null;
 }
 
-export const getAuthToken = (req?: $Request): ?string =>
-  req
-    ? getCookie(AUTH_ACCESS_TOKEN_KEY, req)
-    : lscache.get(AUTH_ACCESS_TOKEN_KEY);
-
-export const getAnonToken = (req?: $Request): ?string =>
-  req
-    ? getCookie(ANON_ACCESS_TOKEN_KEY, req)
-    : lscache.get(ANON_ACCESS_TOKEN_KEY);
+/**
+ * Get the personal token. Works on both the server and the client
+ * @param {*} req
+ */
+export const getPersonalToken = (req?: $Request): ?string =>
+  req ? getCookie(PERSONAL_TOKEN_KEY, req) : Cookie.get(PERSONAL_TOKEN_KEY);
 
 /**
- * Returns auth token or anon token
+ * Get the session token
+ *
+ * This reads from the global object on the server side :(
  */
-export const getAccessTokenFromLocalStorage = (): ?string =>
-  getAuthToken() || getAnonToken();
-
-/**
- * Set access token on the response via cookie
- * NB! Server only
- */
-export function setAnonTokenOnResponse(
-  res: $Response,
-  token: { access_token: string, expires_in: number }
-) {
-  res.cookie(ANON_ACCESS_TOKEN_KEY, token.access_token, {
-    // auth0 returns seconds, but maxAge is in ms
-    maxAge: token.expires_in * 1000
-  });
-}
+export const getSessionToken = (): ?string =>
+  process.browser ? Cookie.get(SESSION_TOKEN_KEY) : global.sessionAccessToken;

--- a/lib/auth/token.js
+++ b/lib/auth/token.js
@@ -9,7 +9,8 @@
 import Cookie from 'js-cookie';
 import type { $Request } from 'express';
 
-const SESSION_TOKEN_KEY = 'session';
+import { RATE_LIMIT_TOKEN_GLOBAL_VAR } from './constants';
+
 const PERSONAL_TOKEN_KEY = 'personal-session';
 export const LOGOUT_KEY = 'logout';
 
@@ -66,5 +67,5 @@ export const getPersonalToken = (req?: $Request): ?string =>
  *
  * This reads from the global object on the server side :(
  */
-export const getSessionToken = (): ?string =>
-  process.browser ? Cookie.get(SESSION_TOKEN_KEY) : global.sessionAccessToken;
+export const getSsrToken = (): ?string =>
+  process.browser ? global[RATE_LIMIT_TOKEN_GLOBAL_VAR] : null;

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "isomorphic-unfetch": "2.0.0",
     "js-cookie": "2.2.0",
     "lingui-react": "1.4.1",
-    "lscache": "1.1.0",
     "next": "4.2.1",
     "next-routes": "1.2.0",
     "polished": "1.9.0",

--- a/pages/auth/sign-off.js
+++ b/pages/auth/sign-off.js
@@ -9,11 +9,11 @@
 import * as React from 'react';
 import defaultPage from '../../hocs/defaultPage';
 import { logout } from '../../lib/auth/';
-import { unsetAuthToken } from '../../lib/auth/token';
+import { unsetPersonalToken } from '../../lib/auth/token';
 
 class SignOff extends React.Component<*> {
   componentDidMount() {
-    unsetAuthToken();
+    unsetPersonalToken();
     logout();
   }
 

--- a/pages/auth/signed-in.js
+++ b/pages/auth/signed-in.js
@@ -13,14 +13,14 @@ import defaultPage from '../../hocs/defaultPage';
 import Layout from '../../components/Layout';
 import Container from '../../components/Container';
 import Box from '../../components/Box';
-import { setAuthToken } from '../../lib/auth/token';
+import { setPersonalToken } from '../../lib/auth/token';
 import { parseHash } from '../../lib/auth';
 
 class Success extends React.Component<*> {
   async componentDidMount() {
     const authResult = await parseHash();
     if (authResult.accessToken) {
-      setAuthToken(authResult);
+      setPersonalToken(authResult);
       Router.push('/');
     }
   }

--- a/pages/books/_book.js
+++ b/pages/books/_book.js
@@ -68,10 +68,10 @@ const Hero = styled('div')`
 `;
 
 class BookPage extends React.Component<Props> {
-  static async getInitialProps({ query, accessToken }: Context) {
+  static async getInitialProps({ query }: Context) {
     const [book, similar] = await Promise.all([
-      fetchBook(query.id, query.lang)(accessToken),
-      fetchSimilarBooks(query.id, query.lang)(accessToken)
+      fetchBook(query.id, query.lang),
+      fetchSimilarBooks(query.id, query.lang)
     ]);
 
     return {

--- a/pages/books/more.js
+++ b/pages/books/more.js
@@ -50,11 +50,11 @@ type State = {
 };
 
 class BookPage extends React.Component<Props, State> {
-  static async getInitialProps({ query, accessToken }: Context) {
+  static async getInitialProps({ query }: Context) {
     const books = await fetchBooks(query.lang, {
       pageSize: PAGE_SIZE,
       level: query.level
-    })(accessToken);
+    });
 
     return {
       books
@@ -83,7 +83,7 @@ class BookPage extends React.Component<Props, State> {
       level: query.level,
       page: this.state.books.page + 1,
       pageSize: PAGE_SIZE
-    })();
+    });
 
     this.setState(state => ({
       isLoadingMore: false,

--- a/pages/books/read.js
+++ b/pages/books/read.js
@@ -23,8 +23,8 @@ type Props = {
 };
 
 class Read extends React.Component<Props> {
-  static async getInitialProps({ query, accessToken }: Context) {
-    const book = await fetchBook(query.id, query.lang)(accessToken);
+  static async getInitialProps({ query }: Context) {
+    const book = await fetchBook(query.id, query.lang);
 
     // Make sure the chapters are sorted by the chapter numbers
     // Cause further down we rely on the array indexes

--- a/pages/index.js
+++ b/pages/index.js
@@ -105,21 +105,21 @@ const HeroCardTablet = styled(Card)`
 `;
 
 class BooksPage extends React.Component<Props> {
-  static async getInitialProps({ query, accessToken }: Context) {
+  static async getInitialProps({ query }: Context) {
     const language: ?string = query.lang;
 
     // Fetch these first, cause they don't use the reading level
     const [featuredContent, levels, languages, justArrived] = await Promise.all(
       [
-        fetchFeaturedContent(language)(accessToken),
-        fetchLevels(language)(accessToken),
-        fetchLanguages()(accessToken),
-        fetchBooks(language)(accessToken)
+        fetchFeaturedContent(language),
+        fetchLevels(language),
+        fetchLanguages(),
+        fetchBooks(language)
       ]
     );
 
     const booksByLevel = await Promise.all(
-      levels.map(level => fetchBooks(language, { level })(accessToken))
+      levels.map(level => fetchBooks(language, { level }))
     );
 
     return {

--- a/pages/package.json
+++ b/pages/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "auth0-js": "8.12.1"
-  }
-}

--- a/pages/user/_translate.js
+++ b/pages/user/_translate.js
@@ -60,10 +60,10 @@ const LinkLike = styled('button')`
 `;
 
 class TranslatePage extends React.Component<Props, State> {
-  static async getInitialProps({ query, accessToken }) {
+  static async getInitialProps({ query }) {
     const [book, supportedLanguages] = await Promise.all([
-      fetchBook(query.id, query.lang)(accessToken),
-      fetchSupportedLanguages()(accessToken)
+      fetchBook(query.id, query.lang),
+      fetchSupportedLanguages()
     ]);
 
     const bookLanguages = book.availableLanguages.map(lang => lang.code);

--- a/pages/user/_translations.js
+++ b/pages/user/_translations.js
@@ -41,7 +41,8 @@ class MyTranslationsPage extends React.Component<Props, State> {
 
   async componentDidMount() {
     const books = await fetchMyTranslations();
-    // eslint-disable-next-line react/no-did-mount-set-state
+    /* eslint-disable react/no-did-mount-set-state */
+    // $FlowFixMe Not sure why Flow complains here....
     this.setState({ books });
   }
 
@@ -56,36 +57,35 @@ class MyTranslationsPage extends React.Component<Props, State> {
           <H1 textAlign="center">
             <Trans>My translations</Trans>
           </H1>
-          {books &&
-            books.results.map(book => (
-              <Card key={book.id} p={[15, 20]} mt={20}>
-                <Flex>
-                  <Box w={[70, 120]} h={[75, 150]}>
-                    <BookCover book={book} />
-                  </Box>
+          {books.results.map(book => (
+            <Card key={book.id} p={[15, 20]} mt={20}>
+              <Flex>
+                <Box w={[70, 120]} h={[75, 150]}>
+                  <BookCover book={book} />
+                </Box>
+                <Box>
+                  <H4>{book.title}</H4>
+                  <P color={theme.colors.grayDark}>
+                    <Trans>from {book.publisher.name}</Trans>
+                  </P>
                   <Box>
-                    <H4>{book.title}</H4>
-                    <P color={theme.colors.grayDark}>
-                      <Trans>from {book.publisher.name}</Trans>
-                    </P>
-                    <Box>
-                      {/* book.translatedFrom.name isn't implmented yet */}
-                      {book.language.name}{' '}
-                      <MdArrowForward color={theme.colors.oranges.orange} />{' '}
-                      <strong>{book.language.name}</strong>
-                    </Box>
-                    <Box ml="auto">
-                      <More>
-                        <MdSettings /> <Trans>Edit</Trans>
-                      </More>
-                      <More>
-                        <MdSync /> <Trans>Sync</Trans>
-                      </More>
-                    </Box>
+                    {/* book.translatedFrom.name isn't implmented yet */}
+                    {book.language.name}{' '}
+                    <MdArrowForward color={theme.colors.oranges.orange} />{' '}
+                    <strong>{book.language.name}</strong>
                   </Box>
-                </Flex>
-              </Card>
-            ))}
+                  <Box ml="auto">
+                    <More>
+                      <MdSettings /> <Trans>Edit</Trans>
+                    </More>
+                    <More>
+                      <MdSync /> <Trans>Sync</Trans>
+                    </More>
+                  </Box>
+                </Box>
+              </Flex>
+            </Card>
+          ))}
         </Container>
       </Layout>
     );

--- a/pages/user/_translations.js
+++ b/pages/user/_translations.js
@@ -11,7 +11,7 @@ import { Trans } from 'lingui-react';
 import type { I18n } from 'lingui-i18n';
 import { MdArrowForward, MdSync, MdSettings } from 'react-icons/lib/md';
 import { fetchMyTranslations } from '../../fetch';
-import type { Book, RemoteData, Context } from '../../types';
+import type { Book, RemoteData } from '../../types';
 import securePage from '../../hocs/securePage';
 import Layout from '../../components/Layout';
 import Box from '../../components/Box';
@@ -27,25 +27,27 @@ import BookCover from '../../components/BookCover';
 import theme from '../../style/theme';
 
 type Props = {
-  books: RemoteData<{ results: Array<Book> }>,
   i18n: I18n
 };
 
-class MyTranslationsPage extends React.Component<Props> {
-  static async getInitialProps({ isAuthenticated }: Context) {
-    if (!isAuthenticated) {
-      return {};
-    }
+type State = {
+  books: RemoteData<{ results: Array<Book> }>
+};
 
+class MyTranslationsPage extends React.Component<Props, State> {
+  state = {
+    books: { results: [] }
+  };
+
+  async componentDidMount() {
     const books = await fetchMyTranslations();
-
-    return {
-      books
-    };
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({ books });
   }
 
   render() {
-    const { books, i18n } = this.props;
+    const { i18n } = this.props;
+    const { books } = this.state;
 
     return (
       <Layout crumbs={[<Trans>My translations</Trans>]}>
@@ -54,35 +56,36 @@ class MyTranslationsPage extends React.Component<Props> {
           <H1 textAlign="center">
             <Trans>My translations</Trans>
           </H1>
-          {books.results.map(book => (
-            <Card key={book.id} p={[15, 20]} mt={20}>
-              <Flex>
-                <Box w={[70, 120]} h={[75, 150]}>
-                  <BookCover book={book} />
-                </Box>
-                <Box>
-                  <H4>{book.title}</H4>
-                  <P color={theme.colors.grayDark}>
-                    <Trans>from {book.publisher.name}</Trans>
-                  </P>
+          {books &&
+            books.results.map(book => (
+              <Card key={book.id} p={[15, 20]} mt={20}>
+                <Flex>
+                  <Box w={[70, 120]} h={[75, 150]}>
+                    <BookCover book={book} />
+                  </Box>
                   <Box>
-                    {/* book.translatedFrom.name isn't implmented yet */}
-                    {book.language.name}{' '}
-                    <MdArrowForward color={theme.colors.oranges.orange} />{' '}
-                    <strong>{book.language.name}</strong>
+                    <H4>{book.title}</H4>
+                    <P color={theme.colors.grayDark}>
+                      <Trans>from {book.publisher.name}</Trans>
+                    </P>
+                    <Box>
+                      {/* book.translatedFrom.name isn't implmented yet */}
+                      {book.language.name}{' '}
+                      <MdArrowForward color={theme.colors.oranges.orange} />{' '}
+                      <strong>{book.language.name}</strong>
+                    </Box>
+                    <Box ml="auto">
+                      <More>
+                        <MdSettings /> <Trans>Edit</Trans>
+                      </More>
+                      <More>
+                        <MdSync /> <Trans>Sync</Trans>
+                      </More>
+                    </Box>
                   </Box>
-                  <Box ml="auto">
-                    <More>
-                      <MdSettings /> <Trans>Edit</Trans>
-                    </More>
-                    <More>
-                      <MdSync /> <Trans>Sync</Trans>
-                    </More>
-                  </Box>
-                </Box>
-              </Flex>
-            </Card>
-          ))}
+                </Flex>
+              </Card>
+            ))}
         </Container>
       </Layout>
     );

--- a/pages/user/_translations.js
+++ b/pages/user/_translations.js
@@ -32,12 +32,12 @@ type Props = {
 };
 
 class MyTranslationsPage extends React.Component<Props> {
-  static async getInitialProps({ accessToken, isAuthenticated }: Context) {
+  static async getInitialProps({ isAuthenticated }: Context) {
     if (!isAuthenticated) {
       return {};
     }
 
-    const books = await fetchMyTranslations()(accessToken);
+    const books = await fetchMyTranslations();
 
     return {
       books

--- a/routes.js
+++ b/routes.js
@@ -24,6 +24,13 @@ if (config.STATIC_PAGES_ONLY) {
   routes.add('about');
   routes.add('login');
   routes.add('logout');
+
+  // Translate book
+  if (config.TRANSLATION_PAGES) {
+    routes.add('translate', '/:lang/translate/:id(\\d+)', 'user/_translate');
+    routes.add('translations', '/translations', 'user/_translations');
+  }
+
   // in other environments we want the books page to be the landing page
   routes.add('books', '/:lang?', 'index');
   // Book grid by level (we only allow a single digit for level, so no + in the regex)
@@ -47,12 +54,6 @@ if (config.STATIC_PAGES_ONLY) {
     '/:lang/books/:id(\\d+)/read/:chapter(\\d+)?',
     'books/read'
   );
-
-  // Translate book
-  if (config.TRANSLATION_PAGES) {
-    routes.add('translate', '/:lang/translate/:id(\\d+)', 'user/_translate');
-    routes.add('translations', '/translations', 'user/_translations');
-  }
 }
 
 module.exports = routes;

--- a/server/index.js
+++ b/server/index.js
@@ -62,13 +62,15 @@ app
       if (!app.isInternalUrl(req)) {
         try {
           const token = await getToken();
-          console.log('Generated token', token);
-          res.cookie('anon-access-token', token.access_token, {
+          res.cookie('session', token.access_token, {
             // auth0 returns seconds, but maxAge is in ms
             maxAge: token.expires_in * 1000
           });
+          global.sessionAccessToken = token.access_token;
         } catch (error) {
-          console.warn('Unable to get token for user. Continuing');
+          console.warn(
+            'Unable to generate token. Session will be rate limited'
+          );
         }
       }
       handle(req, res);

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -1,4 +1,3 @@
-// @flow
 /**
  * Part of GDL gdl-frontend.
  * Copyright (C) 2017 @PROJECT@
@@ -9,7 +8,7 @@
 const fetch = require('isomorphic-unfetch');
 const config = require('../../config');
 
-async function getToken() {
+async function requestToken() {
   const tokenRes = await fetch(config.serverAuth.authUrl, {
     method: 'POST',
     headers: {
@@ -26,17 +25,6 @@ async function getToken() {
   return tokenRes.json();
 }
 
-/* function setToken(
-  res: $Response,
-  token: { access_token: string, expires_in: number }
-) {
-  res.cookie(ANON_ACCESS_TOKEN_KEY, token.access_token, {
-    // auth0 returns seconds, but maxAge is in ms
-    maxAge: token.expires_in * 1000
-  });
-} */
-
 module.exports = {
-  getToken
-  // setToken
+  requestToken
 };

--- a/server/lib/auth.js
+++ b/server/lib/auth.js
@@ -9,24 +9,34 @@
 const fetch = require('isomorphic-unfetch');
 const config = require('../../config');
 
-
 async function getToken() {
   const tokenRes = await fetch(config.serverAuth.authUrl, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       audience: config.serverAuth.audience,
       grant_type: 'client_credentials',
       client_id: config.serverAuth.clientId,
-      client_secret: config.serverAuth.clientSecret,
-    }),
+      client_secret: config.serverAuth.clientSecret
+    })
   });
 
   return tokenRes.json();
 }
 
+/* function setToken(
+  res: $Response,
+  token: { access_token: string, expires_in: number }
+) {
+  res.cookie(ANON_ACCESS_TOKEN_KEY, token.access_token, {
+    // auth0 returns seconds, but maxAge is in ms
+    maxAge: token.expires_in * 1000
+  });
+} */
+
 module.exports = {
-  getToken,
+  getToken
+  // setToken
 };

--- a/types.js
+++ b/types.js
@@ -87,8 +87,5 @@ export type Context = {
   query: { [string]: string },
   err?: Error | { statusCode: number },
   res?: $Response,
-  req?: $Request,
-  // The accessToken isn't really part of the context object passed to
-  accessToken: string,
-  isAuthenticated: boolean
+  req?: $Request
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,10 +5722,6 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lscache@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/lscache/-/lscache-1.1.0.tgz#cbcf2df9ccf634f3c8f9c659bcbe044d6f73b860"
-
 macaddress@^0.2.8:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"


### PR DESCRIPTION
This pull request removes the client side session tokens. Token are now generated on the server only (we still use personal tokens when you log in).

This simplifies lots of stuff, as we don't have to pass tokens around on both the client and the server (because of SSR), and we don't have to renew tokens in the client.

The one small caveat with this is that on the server we place the last requested token in a global variable. Kind of ugly, but it works.

This resolves GlobalDigitalLibraryio/issues#185