### PR TITLE
Https redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pretest": "npm run lint",
     "test": "jest",
     "lint": "eslint --ext .js pages components hocs lib style server",
-    "dev": "npm run i18n:compile && node server",
+    "dev": "node server",
     "build": "npm run i18n:extract && npm run i18n:compile && next build",
     "start": "NODE_ENV=production node server",
     "i18n:extract": "lingui extract",

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,14 @@ const http = require('http');
 const PORT = 3000;
 const REDIRECT_PORT = 3001;
 
-console.log(`> Ready on http://localhost:${PORT}`);
+const initServer = require('./server');
+
+initServer().then(server => {
+  server.listen(PORT, err => {
+    if (err) throw err;
+    console.log(`> Ready on http://localhost:${PORT}`);
+  });
+});
 
 const redirectServer = http.createServer(require('./redirect'));
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,80 +6,18 @@
  * See LICENSE
  */
 
-const express = require('express');
-const next = require('next');
-const requestLanguage = require('express-request-language');
-const cookieParser = require('cookie-parser');
-const glob = require('glob');
-const compression = require('compression');
-const routes = require('../routes');
-const { getToken } = require('./lib/auth');
+const http = require('http');
 
-const dev = process.env.NODE_ENV !== 'production';
-const app = next({ dev });
-const handle = routes.getRequestHandler(app);
+const PORT = 3000;
+const REDIRECT_PORT = 3001;
 
-/* eslint-disable no-console */
+console.log(`> Ready on http://localhost:${PORT}`);
 
-const languages = glob.sync('locale/*/messages.js').map(f => f.split('/')[1]);
-console.log('Found translations for the following languages: ', languages);
+const redirectServer = http.createServer(require('./redirect'));
 
-app
-  .prepare()
-  .then(() => {
-    const server = express();
-
-    // Gzip responses
-    server.use(compression());
-
-    // 404 all requests for favicons since we don't have one, and it attempts to match with our next routes
-    // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
-    server.get('/favicon.ico', (req, res) => res.sendStatus(404));
-
-    /**
-     * Generate access tokens for anonymous users
-     */
-    // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
-    server.get('/get_token', async (req, res) => {
-      try {
-        const token = await getToken();
-        res.json(token);
-      } catch (err) {
-        res.status(500).json({ message: err.message });
-      }
-    });
-
-    // Health check for AWS
-    // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
-    server.get('/health', (req, res) => {
-      res.status(200).json({ status: 200, text: 'Health check ok' });
-    });
-
-    // Setup the cookie parsing for express
-    server.use(cookieParser());
-    // Determine language based on query parameter, cookie, or http accept header
-    // This middleware injects a language property on the request object.
-    server.use(
-      requestLanguage({
-        languages,
-        queryName: 'hl',
-        cookie: {
-          name: 'language'
-        }
-      })
-    );
-
-    // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
-    server.get('*', (req, res) => {
-      handle(req, res);
-    });
-
-    server.listen(3000, err => {
-      if (err) throw err;
-      console.log('> Ready on http://localhost:3000');
-    });
-  })
-  .catch(ex => {
-    console.error(ex.stack);
-    process.exit(1);
-  });
+redirectServer.listen(REDIRECT_PORT);
+redirectServer.on('listening', () => {
+  console.log(
+    `> Listening for insecure redirects on http://localhost:${REDIRECT_PORT}`
+  );
+});

--- a/server/redirect.js
+++ b/server/redirect.js
@@ -1,0 +1,28 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 @PROJECT@
+ *
+ * See LICENSE
+ */
+
+const express = require('express');
+
+const app = express();
+
+/**
+ * Spin up own server for redirecting requests.
+ * ELB routes insecure requests to this server, which returns a permanent secure redirect
+ */
+
+// $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
+app.get('*', (req, res) => {
+  // Prevent ip address leak when empty host
+  const hostname = req.get('Host');
+  if (hostname == null) {
+    res.send(400);
+  }
+  res.direct(301, `https://${hostname}${req.url}`);
+});
+
+module.exports = app;

--- a/server/redirect.js
+++ b/server/redirect.js
@@ -22,7 +22,7 @@ app.get('*', (req, res) => {
   if (hostname == null) {
     res.send(400);
   }
-  res.direct(301, `https://${hostname}${req.url}`);
+  res.redirect(301, `https://${hostname}${req.url}`);
 });
 
 module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,77 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2017 @PROJECT@
+ *
+ * See LICENSE
+ */
+
+const express = require('express');
+const next = require('next');
+const requestLanguage = require('express-request-language');
+const cookieParser = require('cookie-parser');
+const glob = require('glob');
+const compression = require('compression');
+const routes = require('../routes');
+const { getToken } = require('./lib/auth');
+
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = routes.getRequestHandler(app);
+
+const languages = glob.sync('locale/*/messages.js').map(f => f.split('/')[1]);
+console.log('> Found translations for the following languages: ', languages);
+
+async function setup() {
+  await app.prepare();
+  const server = express();
+
+  // Gzip responses
+  server.use(compression());
+
+  // 404 all requests for favicons since we don't have one, and it attempts to match with our next routes
+  // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
+  server.get('/favicon.ico', (req, res) => res.sendStatus(404));
+
+  /**
+   * Generate access tokens for anonymous users
+   */
+  // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
+  server.get('/get_token', async (req, res) => {
+    try {
+      const token = await getToken();
+      res.json(token);
+    } catch (err) {
+      res.status(500).json({ message: err.message });
+    }
+  });
+
+  // Health check for AWS
+  // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
+  server.get('/health', (req, res) => {
+    res.status(200).json({ status: 200, text: 'Health check ok' });
+  });
+
+  // Setup the cookie parsing for express
+  server.use(cookieParser());
+  // Determine language based on query parameter, cookie, or http accept header
+  // This middleware injects a language property on the request object.
+  server.use(
+    requestLanguage({
+      languages,
+      queryName: 'hl',
+      cookie: {
+        name: 'language'
+      }
+    })
+  );
+
+  // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
+  server.get('*', (req, res) => {
+    handle(req, res);
+  });
+
+  return server;
+}
+
+module.exports = setup;


### PR DESCRIPTION
Spin up a new server on another port, whose sole responsibility is to redirect to HTTPS. The ELB must be configured to point insecure requests to the correct port.

This is the frontend part of GlobalDigitalLibraryio/issues#13