### PR TITLE
Add no robots meta tag if not running in production

### DIFF
--- a/__tests__/pages/_document.test.js
+++ b/__tests__/pages/_document.test.js
@@ -19,3 +19,16 @@ test('Sets global GDL environment variable, defaults to \'test\'', () => {
       .html()
   ).toEqual('<script>window.__GDL_ENVIRONMENT__ = \'test\';</script>');
 });
+
+test('Has the no robots meta tag', () => {
+  const tree = shallow(<Document />);
+  expect(
+    tree
+      .find('meta')
+      .filterWhere(
+        meta =>
+          meta.prop('name') === 'robots' && meta.prop('content') === 'noindex'
+      )
+      .exists()
+  ).toBeTruthy();
+});

--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ function getConfig() {
       GLOBAL_VAR_NAME: globalVarName,
       STATIC_PAGES_ONLY: false,
       TRANSLATION_PAGES: true,
+      BLOCK_SEARCH_INDEXING: true,
       clientAuth: {
         clientId: 'Hf3lgXrS71nxiiEaHAyRZ3GncgeE2pq5',
         audience: 'gdl_system',
@@ -55,7 +56,8 @@ function getConfig() {
       bookApiUrl: 'https://api.digitallibrary.io/book-api/v1',
       googleAnalyticsTrackingID: 'UA-111771573-1',
       STATIC_PAGES_ONLY: true,
-      TRANSLATION_PAGES: false
+      TRANSLATION_PAGES: false,
+      BLOCK_SEARCH_INDEXING: false
     }
   };
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -55,6 +55,9 @@ export default class GDLDocument extends Document {
           <meta httpEquiv="x-ua-compatible" content="ie=edge" />
           {/* IE automatically looks for  browserconfig.xml in the root directory of the server if this is not explictly turned off */}
           <meta name="msapplication-config" content="none" />
+          {config.BLOCK_SEARCH_INDEXING && (
+            <meta name="robots" content="noindex" />
+          )}
           {/* Adding next-head to the following meta tag ensures it gets deduped properly on the client in our own Head component */}
           <meta
             property="og:url"


### PR DESCRIPTION
This resolves GlobalDigitalLibraryio/issues#208