### PR TITLE
Load images based on width and resolution

### DIFF
--- a/components/BookCardCover.js
+++ b/components/BookCardCover.js
@@ -34,6 +34,7 @@ export default ({ book, ...props }: { book: Book }) => (
   <Box w={[105, 130]} flex="0 0 auto" {...props}>
     <Card>
       <CoverImage
+        width={[105, 130]}
         h={[130, 160]}
         src={book.coverPhoto && book.coverPhoto.large}
       />

--- a/components/BookCover.js
+++ b/components/BookCover.js
@@ -13,7 +13,8 @@ import type { CoverPhoto } from '../types';
 import theme from '../style/theme';
 
 type Props = {
-  coverPhoto: ?CoverPhoto
+  coverPhoto: ?CoverPhoto,
+  width: [number, number]
 };
 
 const style = css`
@@ -21,9 +22,10 @@ const style = css`
   box-shadow: ${theme.boxShadows.small};
 `;
 
-const BookCover = ({ coverPhoto }: Props) => (
+const BookCover = ({ coverPhoto, width }: Props) => (
   <CoverImage
     className={style}
+    width={width}
     src={coverPhoto && coverPhoto.large}
     h="100%"
     w="100%"

--- a/components/CoverImage.js
+++ b/components/CoverImage.js
@@ -18,9 +18,12 @@ type Props = {
   width: [number, number]
 };
 
+/** Generate srcset value for two different pixels densities */
 function srcSet(url: string, width: number) {
-  return `${url}?focalX=50&focalY=50&ratio=0.81&width=${width} 1x, ${url}?focalX=50&focalY=50&ratio=0.81&width=${width *
-    2} 2x`;
+  const urlWithParams = w => `${url}?focalX=50&focalY=50&ratio=0.81&width=${w}`;
+
+  // Note: 1x descriptior is assumed when left out
+  return `${urlWithParams(width)}, ${urlWithParams(width * 2)} 2x`;
 }
 
 /**

--- a/components/CoverImage.js
+++ b/components/CoverImage.js
@@ -18,12 +18,13 @@ type Props = {
   width: [number, number]
 };
 
+const srcUrl = (src, width) =>
+  `${src}?focalX=50&focalY=50&ratio=0.81&width=${width}`;
+
 /** Generate srcset value for two different pixels densities */
 function srcSet(url: string, width: number) {
-  const urlWithParams = w => `${url}?focalX=50&focalY=50&ratio=0.81&width=${w}`;
-
   // Note: 1x descriptior is assumed when left out
-  return `${urlWithParams(width)}, ${urlWithParams(width * 2)} 2x`;
+  return `${srcUrl(url, width)}, ${srcUrl(url, width * 2)} 2x`;
 }
 
 /**
@@ -32,19 +33,11 @@ function srcSet(url: string, width: number) {
  */
 const CoverImage = ({ src, width, ...props }: Props) => {
   const srcOrPlaceholder =
-    (src && `${src}?focalX=50&focalY=50&ratio=0.81&width=260`) ||
-    NO_COVER_PLACEHOLDER_URL;
+    (src && srcUrl(src, 260)) || NO_COVER_PLACEHOLDER_URL;
 
   if (src == null) {
     return <Image src={NO_COVER_PLACEHOLDER_URL} {...props} />;
   }
-
-  // const srcSet = width.map(w => `${imageSrc(src, w)} ${w}w`).join(', ');
-
-  // Example of resulting string: (min-width: 768px) 260px, 150px
-  /* const sizes = `(min-width: ${TABLET_BREAKPOINT}px): ${width[1]}px, ${
-    width[0]
-  }px`; */
 
   return (
     <Image srcSet={srcSet(src, width[0])} src={srcOrPlaceholder} {...props}>

--- a/components/CoverImage.js
+++ b/components/CoverImage.js
@@ -8,19 +8,49 @@
 
 import * as React from 'react';
 import Image from './Image';
+import { TABLET_BREAKPOINT } from '../style/theme';
 
 const NO_COVER_PLACEHOLDER_URL = require('../static/placeholder-cover.png');
+
+type Props = {
+  src: ?string,
+  // The width of the image for mobile and => tablet
+  width: [number, number]
+};
+
+function srcSet(url: string, width: number) {
+  return `${url}?focalX=50&focalY=50&ratio=0.81&width=${width} 1x, ${url}?focalX=50&focalY=50&ratio=0.81&width=${width *
+    2} 2x`;
+}
 
 /**
  * Add query parameters to book cover images so they fit our wanted ratio
  * This also means we don't download the full image, just the part we want
  */
-const CoverImage = ({ src, ...props }: { src: ?string }) => {
+const CoverImage = ({ src, width, ...props }: Props) => {
   const srcOrPlaceholder =
     (src && `${src}?focalX=50&focalY=50&ratio=0.81&width=260`) ||
     NO_COVER_PLACEHOLDER_URL;
 
-  return <Image src={srcOrPlaceholder} {...props} />;
+  if (src == null) {
+    return <Image src={NO_COVER_PLACEHOLDER_URL} {...props} />;
+  }
+
+  // const srcSet = width.map(w => `${imageSrc(src, w)} ${w}w`).join(', ');
+
+  // Example of resulting string: (min-width: 768px) 260px, 150px
+  /* const sizes = `(min-width: ${TABLET_BREAKPOINT}px): ${width[1]}px, ${
+    width[0]
+  }px`; */
+
+  return (
+    <Image srcSet={srcSet(src, width[0])} src={srcOrPlaceholder} {...props}>
+      <source
+        media={`(min-width: ${TABLET_BREAKPOINT}px)`}
+        srcSet={srcSet(src, width[1])}
+      />
+    </Image>
+  );
 };
 
 export default CoverImage;

--- a/components/Image.js
+++ b/components/Image.js
@@ -77,8 +77,11 @@ type Props = {
   alt?: ?string,
   className?: string,
   src: string,
+  srcSet?: string,
   h?: Array<string | number>,
-  w?: string
+  w?: string,
+  // If source elements are provided, the img will we wrapped in a picture element
+  children?: React.ChildrenArray<React.Element<'source'>>
 };
 
 type State = { isVisible: boolean, imgLoaded: boolean, IOSupported: boolean };
@@ -131,22 +134,36 @@ export default class Image extends React.Component<Props, State> {
     }
   };
 
+  renderImg() {
+    const { src, srcSet, alt } = this.props;
+    return (
+      <Img
+        src={src}
+        srcSet={srcSet}
+        alt={alt}
+        style={{
+          opacity: this.state.imgLoaded ? 1 : 0
+        }}
+        onLoad={() =>
+          this.state.IOSupported && this.setState({ imgLoaded: true })
+        }
+      />
+    );
+  }
+
   render() {
-    const { src, className, alt, h, w } = this.props;
+    const { className, h, w } = this.props;
     return (
       <ImageWrapper className={className} h={h} w={w} innerRef={this.handleRef}>
-        {this.state.isVisible && (
-          <Img
-            src={src}
-            alt={alt}
-            style={{
-              opacity: this.state.imgLoaded ? 1 : 0
-            }}
-            onLoad={() =>
-              this.state.IOSupported && this.setState({ imgLoaded: true })
-            }
-          />
-        )}
+        {this.state.isVisible &&
+          (this.props.children ? (
+            <picture>
+              {this.props.children}
+              {this.renderImg()}
+            </picture>
+          ) : (
+            this.renderImg()
+          ))}
       </ImageWrapper>
     );
   }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -71,7 +71,7 @@ export default class GDLDocument extends Document {
             }}
           />
           <script
-            src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign,String.prototype.includes"
+            src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign,String.prototype.includes,Array.from"
             defer
             async
           />

--- a/pages/books/_book.js
+++ b/pages/books/_book.js
@@ -117,7 +117,7 @@ class BookPage extends React.Component<Props> {
         <Container pt={[15, 20]}>
           <Flex mt={[120, 0]} style={{ position: 'relative' }}>
             <CoverWrap>
-              <BookCover coverPhoto={book.coverPhoto} />
+              <BookCover coverPhoto={book.coverPhoto} width={[150, 260]} />
             </CoverWrap>
             <HeroCard textAlign="center" p={[15, 20]} pt={[80, 20]} flex="1">
               <H1 fontSize={[28, 38]}>{book.title}</H1>

--- a/pages/user/_translate.js
+++ b/pages/user/_translate.js
@@ -133,7 +133,7 @@ class TranslatePage extends React.Component<Props, State> {
                   params={{ lang: book.language.code, id: book.id }}
                 >
                   <a>
-                    <BookCover coverPhoto={book.coverPhoto} />
+                    <BookCover coverPhoto={book.coverPhoto} width={[75, 120]} />
                   </a>
                 </Link>
               </Box>

--- a/pages/user/_translations.js
+++ b/pages/user/_translations.js
@@ -66,7 +66,10 @@ class TranslationCard extends React.Component<
               }}
             >
               <a>
-                <BookCover coverPhoto={translation.coverPhoto} />
+                <BookCover
+                  width={[75, 120]}
+                  coverPhoto={translation.coverPhoto}
+                />
               </a>
             </Link>
           </Box>

--- a/stories/BookCoverExample.js
+++ b/stories/BookCoverExample.js
@@ -59,4 +59,6 @@ const book: Book = {
 storiesOf('BookCover', module)
   .addDecorator(story => <Container mt={50}>{story()}</Container>)
   .add('Book card cover', () => <BookCardCover book={book} />)
-  .add('Book cover', () => <BookCover coverPhoto={book.coverPhoto} />);
+  .add('Book cover', () => (
+    <BookCover width={[50, 150]} coverPhoto={book.coverPhoto} />
+  ));


### PR DESCRIPTION
Add support for picture element, srcset and sizes to book cover component.

This allows us to load images based on screen width and resolution. Meaning we now load fewer bytes of images on mobile.

This resolves GlobalDigitalLibraryio/issues#217