### PR TITLE
Stricter language parameter route matching

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -10,6 +10,9 @@ const config = require('./config');
 
 const routes = nextRoutes();
 
+// For the language parameter, match any combination of alphanumeric and - (Poor man's BCP47 matching!)
+const langParam = `:lang([\\w-]+)`;
+
 // About the global digital library
 routes.add(
   'global-digital-library',
@@ -25,7 +28,7 @@ if (config.STATIC_PAGES_ONLY) {
   if (config.TRANSLATION_PAGES) {
     routes.add(
       'translate',
-      '/:lang/books/translate/:id(\\d+)',
+      `/${langParam}/books/translate/:id(\\d+)`,
       'books/_translate'
     );
     routes.add({
@@ -37,23 +40,23 @@ if (config.STATIC_PAGES_ONLY) {
   routes.add('about');
   routes.add('login');
   routes.add('logout');
-  routes.add('search', '/:lang/search', '_search');
+  routes.add('search', `/${langParam}/search`, '_search');
 
   // in other environments we want the books page to be the landing page
-  routes.add('books', '/:lang?', 'index');
-  routes.add('classroom', '/:lang/books/category/classroom', 'index');
-  routes.add('library', '/:lang/books/category/library', 'index');
+  routes.add('books', `/${langParam}?`, 'index');
+  routes.add('classroom', `/${langParam}/books/category/classroom`, 'index');
+  routes.add('library', `/${langParam}/books/category/library`, 'index');
 
   // Browse the books
-  routes.add('browse', '/:lang/books/browse', 'books/browse');
+  routes.add('browse', `/${langParam}/books/browse`, 'books/browse');
 
   // Book details page
-  routes.add('book', '/:lang/books/details/:id(\\d+)', 'books/_book');
+  routes.add('book', `/${langParam}/books/details/:id(\\d+)`, 'books/_book');
 
   // Read book
   routes.add(
     'read',
-    '/:lang/books/read/:id(\\d+)/:chapter(\\d+)?',
+    `/${langParam}/books/read/:id(\\d+)/:chapter(\\d+)?`,
     'books/read'
   );
 }

--- a/server/server.js
+++ b/server/server.js
@@ -24,10 +24,6 @@ async function setup() {
   await app.prepare();
   const server = express();
 
-  // 404 all requests for favicons since we don't have one, and it attempts to match with our next routes
-  // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
-  server.get('/favicon.ico', (req, res) => res.sendStatus(404));
-
   // Health check for AWS
   // $FlowFixMe: https://github.com/flowtype/flow-typed/issues/1120
   server.get('/health', (req, res) => {


### PR DESCRIPTION
To prevent requests with filenames being interpreted as a language
parameter, such as host/robots.txt

This resolves GlobalDigitalLibraryio/issues#287

