### PR TITLE
Explicitly import icons to reduce bundle size

### DIFF
--- a/components/Flag/index.js
+++ b/components/Flag/index.js
@@ -7,7 +7,10 @@
  */
 
 import React, { type Element } from 'react';
-import { MdStar, MdWarning, MdInfo, MdClose } from 'react-icons/lib/md';
+import MdStar from 'react-icons/lib/md/star';
+import MdWarning from 'react-icons/lib/md/warning';
+import MdInfo from 'react-icons/lib/md/info';
+import MdClose from 'react-icons/lib/md/close';
 import { Trans } from '@lingui/react';
 import { Container, DismissButton, Icon, Text } from './styledFlag';
 import SrOnly from '../SrOnly';

--- a/components/Menu/Header.js
+++ b/components/Menu/Header.js
@@ -6,7 +6,8 @@
  * See LICENSE
  */
 import React, { type Element } from 'react';
-import { MdClose, MdArrowBack } from 'react-icons/lib/md';
+import MdClose from 'react-icons/lib/md/close';
+import MdArrowBack from 'react-icons/lib/md/arrow-back';
 import { Trans } from '@lingui/react';
 
 import { Header, Title, Button } from './styled/Content';

--- a/components/Menu/MenuItem.js
+++ b/components/Menu/MenuItem.js
@@ -6,7 +6,8 @@
  * See LICENSE
  */
 import React, { type Node } from 'react';
-import { MdCheck, MdKeyboardArrowRight } from 'react-icons/lib/md';
+import MdCheck from 'react-icons/lib/md/check';
+import MdKeyboardArrowRight from 'react-icons/lib/md/keyboard-arrow-right';
 import { Trans } from '@lingui/react';
 import { cx } from 'react-emotion';
 

--- a/components/NavContextBar/Breadcrumb.js
+++ b/components/NavContextBar/Breadcrumb.js
@@ -7,7 +7,8 @@
  */
 
 import * as React from 'react';
-import { MdKeyboardArrowRight, MdHome } from 'react-icons/lib/md';
+import MdKeyboardArrowRight from 'react-icons/lib/md/keyboard-arrow-right';
+import MdHome from 'react-icons/lib/md/home';
 import { withI18n } from '@lingui/react';
 import styled, { css } from 'react-emotion';
 import theming from 'styled-theming';

--- a/components/Navbar/index.js
+++ b/components/Navbar/index.js
@@ -7,7 +7,8 @@
  */
 
 import * as React from 'react';
-import { MdMenu, MdSearch } from 'react-icons/lib/md';
+import MdSearch from 'react-icons/lib/md/search';
+import MdMenu from 'react-icons/lib/md/menu';
 import { Trans } from '@lingui/react';
 
 import { Link } from '../../routes';

--- a/components/Reader/ButtonOverlay.js
+++ b/components/Reader/ButtonOverlay.js
@@ -6,7 +6,8 @@
  * See LICENSE
  */
 import * as React from 'react';
-import { MdKeyboardArrowRight, MdKeyboardArrowLeft } from 'react-icons/lib/md';
+import MdKeyboardArrowRight from 'react-icons/lib/md/keyboard-arrow-right';
+import MdKeyboardArrowLeft from 'react-icons/lib/md/keyboard-arrow-left';
 import { Trans } from '@lingui/react';
 import styled from 'react-emotion';
 import SrOnly from '../SrOnly';

--- a/components/Reader/Toolbar.js
+++ b/components/Reader/Toolbar.js
@@ -8,7 +8,8 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import { Trans } from '@lingui/react';
-import { MdClose, MdEdit } from 'react-icons/lib/md';
+import MdClose from 'react-icons/lib/md/close';
+import MdEdit from 'react-icons/lib/md/edit';
 
 import type { BookDetails, ChapterSummary } from '../../types';
 import { Link } from '../../routes';

--- a/components/Search/components/SearchField/index.js
+++ b/components/Search/components/SearchField/index.js
@@ -6,7 +6,7 @@
  * See LICENSE
  */
 import * as React from 'react';
-import { MdSearch } from 'react-icons/lib/md';
+import MdSearch from 'react-icons/lib/md/search';
 import { Input, Label, Container, Icon } from './styled';
 
 type Props = {

--- a/pages/auth/sign-in.js
+++ b/pages/auth/sign-in.js
@@ -9,7 +9,8 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import { Trans } from '@lingui/react';
-import { FaGoogle, FaFacebook } from 'react-icons/lib/fa';
+import FaFacebook from 'react-icons/lib/fa/facebook';
+import FaGoogle from 'react-icons/lib/fa/google';
 
 import type { I18n } from '../../types';
 import { Text, A } from '../../elements';

--- a/pages/books/_translate.js
+++ b/pages/books/_translate.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 import { Trans } from '@lingui/react';
-import { MdArrowDownward } from 'react-icons/lib/md';
+import MdArrowDownward from 'react-icons/lib/md/arrow-downward';
 
 import {
   fetchBook,

--- a/pages/books/translations.js
+++ b/pages/books/translations.js
@@ -8,7 +8,7 @@
 
 import * as React from 'react';
 import { Trans } from '@lingui/react';
-import { MdArrowForward } from 'react-icons/lib/md';
+import MdArrowForward from 'react-icons/lib/md/arrow-forward';
 import doFetch, { fetchMyTranslations } from '../../fetch';
 import { Link } from '../../routes';
 import type { Translation, I18n } from '../../types';


### PR DESCRIPTION
By importing each icon explicitly we're able to significantly shave down the bundle size (pre gzipping).

Before: `1.2M main.js`
After: `465K main.js`

Which amounts to a decrease of a whoppin whole 61.25% 🎉