### PR TITLE
Improve scrolling in menus on mobile

### DIFF
--- a/components/Menu/styled/Content.js
+++ b/components/Menu/styled/Content.js
@@ -18,7 +18,7 @@ export const Wrapper = styled('div')`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  height: 100vh;
+  height: 100%;
   min-height: 0;
 `;
 

--- a/components/Menu/styled/Dialog.js
+++ b/components/Menu/styled/Dialog.js
@@ -20,7 +20,6 @@ export const FillScreen = styled('div')`
   position: absolute;
   width: 100%;
   z-index: 510;
-  -webkit-overflow-scrolling: touch;
 `;
 
 export const Positioner = styled('div')`

--- a/components/Menu/styled/Dialog.js
+++ b/components/Menu/styled/Dialog.js
@@ -13,7 +13,7 @@ import media from '../../../style/media';
 const MENU_WIDTH = '375px';
 
 export const FillScreen = styled('div')`
-  height: 100vh;
+  height: 100%;
   left: 0;
   top: 0;
   overflow-y: auto;
@@ -23,6 +23,7 @@ export const FillScreen = styled('div')`
 `;
 
 export const Positioner = styled('div')`
+  height: 100%;
   position: absolute;
   top: 0;
   left: 0;
@@ -55,6 +56,7 @@ export const Dialog = styled('div')`
   background-color: #fff;
   display: flex;
   flex-direction: column;
+  height: 100%;
   outline: 0;
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.12), 0 0 2px 0 rgba(0, 0, 0, 0.12),
     0 4px 20px 0 rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
For the menus on mobile, don't use vh units for fullscreen, as they're really troublesome.

Fixes https://github.com/GlobalDigitalLibraryio/issues/issues/340