### PR TITLE
SEO: Paginated content and canonical URL

### DIFF
--- a/components/Reader/index.js
+++ b/components/Reader/index.js
@@ -8,6 +8,8 @@
 import * as React from 'react';
 import styled from 'react-emotion';
 import Swipeable from 'react-swipeable';
+import Head from 'next/head';
+
 import { fetchChapter } from '../../fetch';
 import Box from '../Box';
 import type { BookDetails, Chapter, ChapterSummary } from '../../types';
@@ -262,16 +264,35 @@ export default class ReaderContainer extends React.Component<
   }
 
   render() {
+    const next = this.getNextChapterPointer();
+    const prev = this.getPreviousChapterPointer();
+    const { book } = this.props;
     return (
-      <Reader
-        book={this.props.book}
-        chapterWithContent={this.state.chapters[this.state.chapterPointer.id]}
-        chapterPointer={this.state.chapterPointer}
-        onRequestNext={this.handleRequestNextChapter}
-        onRequestPrevious={this.handleRequestPreviousChapter}
-        onRequestClose={this.handleRequestCloseBook}
-        userHasEditAccess={this.props.userHasEditAccess}
-      />
+      <React.Fragment>
+        <Head>
+          {prev && (
+            <link
+              rel="prev"
+              href={`/${book.language.code}/books/read/${book.id}/${prev.id}`}
+            />
+          )}
+          {next && (
+            <link
+              rel="next"
+              href={`/${book.language.code}/books/read/${book.id}/${next.id}`}
+            />
+          )}
+        </Head>
+        <Reader
+          book={this.props.book}
+          chapterWithContent={this.state.chapters[this.state.chapterPointer.id]}
+          chapterPointer={this.state.chapterPointer}
+          onRequestNext={this.handleRequestNextChapter}
+          onRequestPrevious={this.handleRequestPreviousChapter}
+          onRequestClose={this.handleRequestCloseBook}
+          userHasEditAccess={this.props.userHasEditAccess}
+        />
+      </React.Fragment>
     );
   }
 }

--- a/config.js
+++ b/config.js
@@ -50,29 +50,34 @@ function getConfig() {
     },
 
     dev: {
-      bookApiUrl: 'https://api.test.digitallibrary.io/book-api/v1'
+      bookApiUrl: 'https://api.test.digitallibrary.io/book-api/v1',
+      canonical: 'http://localhost:3000'
     },
 
     local: {
-      bookApiUrl: 'http://book-api.gdl-local:40001/book-api/v1'
+      bookApiUrl: 'http://book-api.gdl-local:40001/book-api/v1',
+      canonical: 'http://localhost:40003'
     },
 
     test: {
       bookApiUrl: 'https://api.test.digitallibrary.io/book-api/v1',
       REPORT_ERRORS: true,
-      googleAnalyticsTrackingID: 'UA-111724798-1'
+      googleAnalyticsTrackingID: 'UA-111724798-1',
+      canonical: 'https://test.digitallibrary.io'
     },
 
     staging: {
       bookApiUrl: 'https://api.staging.digitallibrary.io/book-api/v1',
       REPORT_ERRORS: true,
-      googleAnalyticsTrackingID: 'UA-111796456-1'
+      googleAnalyticsTrackingID: 'UA-111796456-1',
+      canonical: 'https://staging.digitallibrary.io'
     },
 
     prod: {
       bookApiUrl: 'https://api.digitallibrary.io/book-api/v1',
       REPORT_ERRORS: true,
       googleAnalyticsTrackingID: 'UA-111771573-1',
+      canonical: 'https://digitallibrary.io',
       BLOCK_SEARCH_INDEXING: false
     }
   };

--- a/hocs/withI18n.js
+++ b/hocs/withI18n.js
@@ -11,13 +11,16 @@ import { I18nProvider, withI18n } from '@lingui/react';
 import Head from 'next/head';
 import Url from 'domurl';
 import type { Context } from '../types';
+import { canonical } from '../config';
 // Currently we only support English
 import catalog from '../locale/en/messages';
 
 type Props = {
   language: string,
   catalog: string,
-  href: string
+  url: {
+    asPath: string
+  }
 };
 
 // For now we have to add each translation here
@@ -51,26 +54,16 @@ export default (Page: React.ComponentType<any>) => {
         language = 'en';
       }
 
-      let href;
-      if (req != null) {
-        // On the server, we build it up based on the request object
-        href = `${req.protocol}://${req.headers.host}${req.originalUrl}`;
-      } else {
-        // In the browser, we simly read the window location
-        href = window.location.href;
-      }
-
       return {
         ...composedInitialProps,
-        language,
-        href
+        language
       };
     }
 
     render() {
       const languages = Object.keys(translations);
-      const { language, href, ...props } = this.props;
-      const url = new Url(href);
+      const { language, ...props } = this.props;
+      const url = new Url(`${canonical}/${props.url.asPath}`);
       delete url.query.hl;
       // Wrap our page with the i18n provider and add alternate links to the other supported languages in the head
 

--- a/pages/books/_read.js
+++ b/pages/books/_read.js
@@ -15,6 +15,7 @@ import defaultPage from '../../hocs/defaultPage';
 import errorPage from '../../hocs/errorPage';
 import Head from '../../components/Head';
 import Reader from '../../components/Reader';
+import { canonical } from '../../config';
 
 type Props = {
   book: BookDetails,
@@ -59,7 +60,7 @@ class Read extends React.Component<Props> {
   }
 
   render() {
-    let { book, chapter, userHasEditAccess } = this.props;
+    const { book, chapter, userHasEditAccess } = this.props;
 
     return (
       <React.Fragment>
@@ -67,7 +68,16 @@ class Read extends React.Component<Props> {
           title={`Read: ${book.title}`}
           description={book.description}
           image={book.coverImage && book.coverImage.url}
-        />
+        >
+          {!this.props.url.query.chapterId && (
+            <link
+              rel="canonical"
+              href={`${canonical}/${book.language.code}/books/${book.id}/read/${
+                chapter.id
+              }`}
+            />
+          )}
+        </Head>
 
         <Reader
           book={book}

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,6 +26,7 @@ import {
   getBookLanguageCode,
   getBookCategory
 } from '../lib/storage';
+import { canonical } from '../config';
 
 type Props = {|
   featuredContent: Array<FeaturedContent>,
@@ -33,8 +34,7 @@ type Props = {|
   levels: Array<ReadingLevel>,
   booksByLevel: Array<{ results: Array<Book> }>,
   category: Category,
-  categories: Array<Category>,
-  locationOrigin: string
+  categories: Array<Category>
 |};
 
 class IndexPage extends React.Component<Props> {
@@ -105,19 +105,12 @@ class IndexPage extends React.Component<Props> {
     // $FlowFixMe: We know this is a valid category :/
     setBookLanguageAndCategory(newArrivals.language, category, res);
 
-    // THe URL is needed so we can create a canonical URL
-    const locationOrigin =
-      req != null
-        ? `${req.protocol}://${req.headers.host}`
-        : window.location.origin;
-
     return {
       category,
       featuredContent,
       newArrivals,
       levels,
       booksByLevel,
-      locationOrigin,
       categories: Object.keys(categories)
     };
   }
@@ -137,7 +130,6 @@ class IndexPage extends React.Component<Props> {
       levels,
       booksByLevel,
       newArrivals,
-      locationOrigin,
       categories
     } = this.props;
 
@@ -156,13 +148,13 @@ class IndexPage extends React.Component<Props> {
           <Head>
             <link
               rel="canonical"
-              href={`${locationOrigin}/${
+              href={`${canonical}/${
                 language.code
               }/books/category/${categoryTypeForUrl}`}
             />
             <meta
               property="og:url"
-              content={`${locationOrigin}/${
+              content={`${canonical}/${
                 language.code
               }/books/category/${categoryTypeForUrl}`}
             />


### PR DESCRIPTION
SEO: Indicate [paginated content](https://support.google.com/webmasters/answer/1663744?hl=en) for book chapters.

Define canonical URL in config. Simplifies things as we don't have to read it from different sources on the client and the server. This also ensures that we set the canonical url as `digitallibrary.io`, not `www.digitallibrary.io` even if the latter is accessed.

Resolves https://github.com/GlobalDigitalLibraryio/issues/issues/341