### PR TITLE
Lazy load auth0 to reduce bundle

### DIFF
--- a/packages/gdl-frontend/lib/auth/index.js
+++ b/packages/gdl-frontend/lib/auth/index.js
@@ -6,9 +6,10 @@
  * See LICENSE
  */
 
-import auth0 from 'auth0-js';
 import lscache from 'lscache';
 import { clientAuth } from '../../config';
+// Dynamic import to reduce bundle size
+const auth0 = import('auth0-js');
 
 export const setRedirectUrl = (path: { asPath: string, pathname: string }) =>
   lscache.set('REDIRECT_AFTER_LOGIN', path, 5);
@@ -45,10 +46,12 @@ export function parseHash(
   });
 }
 
-export function loginSocialMedia(type: 'facebook' | 'google-oauth2') {
-  getAuth().authorize({
+export async function loginSocialMedia(type: 'facebook' | 'google-oauth2') {
+  (await getAuth()).authorize({
     connection: type
   });
 }
 
-export const logout = () => getAuth().logout({ returnTo: getBaseUrl() });
+export const logout = async () => {
+  (await getAuth()).logout({ returnTo: getBaseUrl() });
+};


### PR DESCRIPTION
This pull req will make the auth0 dependency load dynamically, on demand.
This will pull it out into it's own chunk. Most of our users don't sign in, so this is a nice win for them. As it reduces the initial bundle by a litte over 100 KB (uncompressed).

Before:
<img width="92" alt="screen shot 2018-06-12 at 07 29 04" src="https://user-images.githubusercontent.com/81577/41286750-dcad9b14-6e40-11e8-89a8-702340bd7a4e.png">

After:
<img width="91" alt="screen shot 2018-06-12 at 07 32 09" src="https://user-images.githubusercontent.com/81577/41286755-e4316c62-6e40-11e8-82d0-d7acdb1fee42.png">

This closes https://github.com/GlobalDigitalLibraryio/issues/issues/367