### PR TITLE
Revert book cover as link to read book page

### DIFF
--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -145,20 +145,11 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
             <View flexDirection="row" mt={['135px', spacing.medium]}>
               <CoverWrap>
                 <View>
-                  <Link
-                    route="read"
-                    passHref
-                    params={{ id: book.id, lang: book.language.code }}
-                    prefetch
-                  >
-                    <a title={book.title} aria-hidden>
-                      <BookCover
-                        coverImage={book.coverImage}
-                        w={[130, 260]}
-                        h={[175, 365]}
-                      />
-                    </a>
-                  </Link>
+                  <BookCover
+                    coverImage={book.coverImage}
+                    w={[130, 260]}
+                    h={[175, 365]}
+                  />
                   {this.props.userHasEditImageAccess && (
                     <NextLink
                       href={{


### PR DESCRIPTION
PDF only books doesn't aren't readable. Feels weird with different
behaviour for the two types of book.

This resolves https://github.com/GlobalDigitalLibraryio/issues/issues/419