### PR TITLE
Mark books as favorites

### DIFF
--- a/packages/gdl-frontend/components/Favorite.js
+++ b/packages/gdl-frontend/components/Favorite.js
@@ -1,0 +1,64 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2018 GDL
+ *
+ * See LICENSE
+ */
+
+import * as React from 'react';
+import { markAsFavorite, removeAsFavorite, isFavorite } from '../lib/favorites';
+
+type Props = {
+  id: number,
+  language: string,
+  children: (data: { isFav: boolean, onClick: () => void }) => React.Node
+};
+
+export default class Favorite extends React.Component<
+  Props,
+  { isFav: boolean }
+> {
+  state = {
+    isFav: false
+  };
+
+  componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.id !== this.props.id ||
+      prevProps.language !== this.props.language
+    ) {
+      this.updateFavState();
+    }
+  }
+
+  componentDidMount() {
+    this.updateFavState();
+  }
+
+  updateFavState = () => {
+    const isFav = isFavorite({
+      id: this.props.id,
+      language: this.props.language
+    });
+
+    if (isFav !== this.state.isFav) {
+      this.setState({ isFav });
+    }
+  };
+
+  handleClick = () => {
+    const fav = { id: this.props.id, language: this.props.language };
+
+    this.state.isFav ? removeAsFavorite(fav) : markAsFavorite(fav);
+
+    this.setState(state => ({ isFav: !this.state.isFav }));
+  };
+
+  render() {
+    return this.props.children({
+      isFav: this.state.isFav,
+      onClick: this.handleClick
+    });
+  }
+}

--- a/packages/gdl-frontend/components/GlobalMenu/index.js
+++ b/packages/gdl-frontend/components/GlobalMenu/index.js
@@ -21,7 +21,8 @@ import {
   KeyboardArrowRight as KeyboardArrowRightIcon,
   ExitToApp as ExitToAppIcon,
   Translate as TranslateIcon,
-  Edit as EditIcon
+  Edit as EditIcon,
+  Favorite as FavoriteIcon
 } from '@material-ui/icons';
 
 import type { Language } from '../../types';
@@ -101,6 +102,16 @@ class GlobalMenu extends React.Component<Props, State> {
               </ListItemText>
             </ListItem>
           )}
+          <RouteLink passHref route="favorites">
+            <ListItem button component="a">
+              <ListItemIcon>
+                <FavoriteIcon />
+              </ListItemIcon>
+              <ListItemText>
+                <Trans>Favorites</Trans>
+              </ListItemText>
+            </ListItem>
+          </RouteLink>
           <RouteLink passHref route="translations">
             <ListItem button component="a">
               <ListItemIcon>

--- a/packages/gdl-frontend/components/Reader/Toolbar.js
+++ b/packages/gdl-frontend/components/Reader/Toolbar.js
@@ -9,7 +9,12 @@ import * as React from 'react';
 import styled from 'react-emotion';
 import { Trans } from '@lingui/react';
 import { IconButton } from '@material-ui/core';
-import { Close as CloseIcon, Edit as EditIcon } from '@material-ui/icons';
+import {
+  Close as CloseIcon,
+  Edit as EditIcon,
+  Favorite as FavoriteIcon,
+  FavoriteBorder as FavoriteOutlineIcon
+} from '@material-ui/icons';
 
 import type { BookDetails, ChapterSummary } from '../../types';
 import { Link } from '../../routes';
@@ -76,6 +81,21 @@ const Toolbar = ({
         </IconButton>
       </Link>
     )}
+    <IconButton
+      onClick={onRequestClose}
+      css={`
+        position: absolute;
+        right: 50px;
+        &:hover {
+          color: red;
+        }
+      `}
+    >
+      <FavoriteOutlineIcon />
+      <SrOnly>
+        <Trans>Mark book as favorite</Trans>
+      </SrOnly>
+    </IconButton>
     <IconButton
       onClick={onRequestClose}
       css={{ position: 'absolute', right: '0' }}

--- a/packages/gdl-frontend/components/Reader/Toolbar.js
+++ b/packages/gdl-frontend/components/Reader/Toolbar.js
@@ -99,13 +99,16 @@ const Toolbar = ({
   </Div>
 );
 
-class FavButton extends React.Component {
+class FavButton extends React.Component<
+  { book: BookDetails },
+  { isFav: boolean }
+> {
   state = {
-    client: false
+    isFav: false
   };
 
   componentDidMount() {
-    this.setState({ client: true, isFav: isFavorite(this.props.book) });
+    this.setState({ isFav: isFavorite(this.props.book) });
   }
 
   handleFav = () => {
@@ -117,7 +120,6 @@ class FavButton extends React.Component {
   };
 
   render() {
-    if (!this.state.client) return null;
     const isFav = this.state.isFav;
     return (
       <IconButton

--- a/packages/gdl-frontend/components/Reader/Toolbar.js
+++ b/packages/gdl-frontend/components/Reader/Toolbar.js
@@ -22,7 +22,11 @@ import SrOnly from '../SrOnly';
 import { colors } from '../../style/theme';
 import media from '../../style/media';
 import { flexCenter } from '../../style/flex';
-import { markAsFavorite, isFavorite } from '../../lib/favorites';
+import {
+  markAsFavorite,
+  removeAsFavorite,
+  isFavorite
+} from '../../lib/favorites';
 
 const Div = styled.div`
   z-index: 2;
@@ -101,16 +105,23 @@ class FavButton extends React.Component {
   };
 
   componentDidMount() {
-    this.setState({ client: true });
+    this.setState({ client: true, isFav: isFavorite(this.props.book) });
   }
 
+  handleFav = () => {
+    this.state.isFav
+      ? removeAsFavorite(this.props.book)
+      : markAsFavorite(this.props.book);
+
+    this.setState({ isFav: isFavorite(this.props.book) });
+  };
+
   render() {
-    const { book } = this.props;
     if (!this.state.client) return null;
-    const isFav = isFavorite(book);
+    const isFav = this.state.isFav;
     return (
       <IconButton
-        onClick={() => markAsFavorite(book)}
+        onClick={this.handleFav}
         css={`
           position: absolute;
           right: 50px;

--- a/packages/gdl-frontend/components/Reader/Toolbar.js
+++ b/packages/gdl-frontend/components/Reader/Toolbar.js
@@ -22,6 +22,7 @@ import SrOnly from '../SrOnly';
 import { colors } from '../../style/theme';
 import media from '../../style/media';
 import { flexCenter } from '../../style/flex';
+import { markAsFavorite, isFavorite } from '../../lib/favorites';
 
 const Div = styled.div`
   z-index: 2;
@@ -81,21 +82,7 @@ const Toolbar = ({
         </IconButton>
       </Link>
     )}
-    <IconButton
-      onClick={onRequestClose}
-      css={`
-        position: absolute;
-        right: 50px;
-        &:hover {
-          color: red;
-        }
-      `}
-    >
-      <FavoriteOutlineIcon />
-      <SrOnly>
-        <Trans>Mark book as favorite</Trans>
-      </SrOnly>
-    </IconButton>
+    <FavButton book={book} />
     <IconButton
       onClick={onRequestClose}
       css={{ position: 'absolute', right: '0' }}
@@ -107,5 +94,36 @@ const Toolbar = ({
     </IconButton>
   </Div>
 );
+
+class FavButton extends React.Component {
+  state = {
+    client: false
+  };
+
+  componentDidMount() {
+    this.setState({ client: true });
+  }
+
+  render() {
+    const { book } = this.props;
+    if (!this.state.client) return null;
+    const isFav = isFavorite(book);
+    return (
+      <IconButton
+        onClick={() => markAsFavorite(book)}
+        css={`
+          position: absolute;
+          right: 50px;
+        `}
+        style={isFav ? { color: 'red' } : null}
+      >
+        {isFav ? <FavoriteIcon /> : <FavoriteOutlineIcon />}
+        <SrOnly>
+          <Trans>Mark book as favorite</Trans>
+        </SrOnly>
+      </IconButton>
+    );
+  }
+}
 
 export default Toolbar;

--- a/packages/gdl-frontend/elements/Center.js
+++ b/packages/gdl-frontend/elements/Center.js
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { css, cx } from 'react-emotion';
+
+const style = css`
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+`;
+
+type Props = {
+  className?: string
+};
+
+/**
+ * Flex centered column
+ */
+const Center = ({ className, ...props }: Props) => (
+  <div className={cx(style, className)} {...props} />
+);
+
+export default Center;

--- a/packages/gdl-frontend/elements/index.js
+++ b/packages/gdl-frontend/elements/index.js
@@ -11,3 +11,4 @@ export { default as View } from './View';
 export { default as Container } from './Container';
 export { default as LoadingButton } from './LoadingButton';
 export { default as DelayedLoading } from './DelayedLoading';
+export { default as Center } from './Center';

--- a/packages/gdl-frontend/lib/favorites.js
+++ b/packages/gdl-frontend/lib/favorites.js
@@ -9,20 +9,28 @@ import lscache from 'lscache';
 import type { Book } from '../types';
 
 const FAVORITES_KEY = 'favorites';
+type Fav = { id: number, lang: string };
 
-export function markFavorite(book: Book) {
+export function markAsFavorite(book: Book) {
   const favs = [...getFavorites(), { id: book.id, lang: book.language.code }];
   setFavorites(favs);
 }
 
-export function removeFavorite(book: Book) {
+export function removeAsFavorite(book: Book) {
   const favs = getFavorites().filter(
-    fav => fav.id === book.id && fav.lang === book.language.code
+    fav => !(fav.id === book.id && fav.lang === book.language.code)
   );
   setFavorites(favs);
 }
 
-export function getFavorites(): Array<string> {
+export function isFavorite(book: Book) {
+  const favs = getFavorites();
+  return Boolean(
+    favs.find(f => f.id === book.id && f.lang === book.language.code)
+  );
+}
+
+export function getFavorites(): Array<Fav> {
   return lscache.get(FAVORITES_KEY) || [];
 }
 

--- a/packages/gdl-frontend/lib/favorites.js
+++ b/packages/gdl-frontend/lib/favorites.js
@@ -6,24 +6,27 @@
  * See LICENSE
  */
 import lscache from 'lscache';
-import type { Book } from '../types';
+import type { BookDetails } from '../types';
 
 const FAVORITES_KEY = 'favorites';
 type Fav = { id: number, lang: string };
 
-export function markAsFavorite(book: Book) {
-  const favs = [...getFavorites(), { id: book.id, lang: book.language.code }];
-  setFavorites(favs);
+export function markAsFavorite(book: BookDetails) {
+  // Make sure we don't add the same book multiple times
+  if (!isFavorite(book)) {
+    const favs = [{ id: book.id, lang: book.language.code }, ...getFavorites()];
+    setFavorites(favs);
+  }
 }
 
-export function removeAsFavorite(book: Book) {
+export function removeAsFavorite(book: BookDetails) {
   const favs = getFavorites().filter(
     fav => !(fav.id === book.id && fav.lang === book.language.code)
   );
   setFavorites(favs);
 }
 
-export function isFavorite(book: Book) {
+export function isFavorite(book: BookDetails) {
   const favs = getFavorites();
   return Boolean(
     favs.find(f => f.id === book.id && f.lang === book.language.code)

--- a/packages/gdl-frontend/lib/favorites.js
+++ b/packages/gdl-frontend/lib/favorites.js
@@ -9,19 +9,29 @@ import lscache from 'lscache';
 import type { BookDetails } from '../types';
 
 const FAVORITES_KEY = 'favorites';
-type Fav = { id: number, lang: string };
+// The object format that we store for each favorite
+type Fav = { id: number, language: string };
 
 export function markAsFavorite(book: BookDetails) {
   // Make sure we don't add the same book multiple times
   if (!isFavorite(book)) {
-    const favs = [{ id: book.id, lang: book.language.code }, ...getFavorites()];
+    const favs = [
+      { id: book.id, language: book.language.code },
+      ...getFavorites()
+    ];
     setFavorites(favs);
   }
 }
 
-export function removeAsFavorite(book: BookDetails) {
+/**
+ * Supports both a full book object and a simple fav object
+ */
+export function removeAsFavorite(book: BookDetails | Fav) {
+  const language =
+    typeof book.language === 'string' ? book.language : book.language.code;
+
   const favs = getFavorites().filter(
-    fav => !(fav.id === book.id && fav.lang === book.language.code)
+    fav => !(fav.id === book.id && fav.language === language)
   );
   setFavorites(favs);
 }
@@ -29,12 +39,16 @@ export function removeAsFavorite(book: BookDetails) {
 export function isFavorite(book: BookDetails) {
   const favs = getFavorites();
   return Boolean(
-    favs.find(f => f.id === book.id && f.lang === book.language.code)
+    favs.find(f => f.id === book.id && f.language === book.language.code)
   );
 }
 
 export function getFavorites(): Array<Fav> {
   return lscache.get(FAVORITES_KEY) || [];
+}
+
+export function clearFavorites() {
+  lscache.remove(FAVORITES_KEY);
 }
 
 function setFavorites(favs) {

--- a/packages/gdl-frontend/lib/favorites.js
+++ b/packages/gdl-frontend/lib/favorites.js
@@ -6,40 +6,30 @@
  * See LICENSE
  */
 import lscache from 'lscache';
-import type { BookDetails } from '../types';
 
 const FAVORITES_KEY = 'favorites';
 // The object format that we store for each favorite
 type Fav = { id: number, language: string };
 
-export function markAsFavorite(book: BookDetails) {
+export function markAsFavorite(fav: Fav) {
   // Make sure we don't add the same book multiple times
-  if (!isFavorite(book)) {
-    const favs = [
-      { id: book.id, language: book.language.code },
-      ...getFavorites()
-    ];
+  if (!isFavorite(fav)) {
+    const favs = [{ id: fav.id, language: fav.language }, ...getFavorites()];
     setFavorites(favs);
   }
 }
 
-/**
- * Supports both a full book object and a simple fav object
- */
-export function removeAsFavorite(book: BookDetails | Fav) {
-  const language =
-    typeof book.language === 'string' ? book.language : book.language.code;
-
+export function removeAsFavorite(fav: Fav) {
   const favs = getFavorites().filter(
-    fav => !(fav.id === book.id && fav.language === language)
+    f => !(fav.id === f.id && fav.language === f.language)
   );
   setFavorites(favs);
 }
 
-export function isFavorite(book: BookDetails) {
+export function isFavorite(fav: Fav) {
   const favs = getFavorites();
   return Boolean(
-    favs.find(f => f.id === book.id && f.language === book.language.code)
+    favs.find(f => f.id === fav.id && f.language === fav.language)
   );
 }
 

--- a/packages/gdl-frontend/lib/favorites.js
+++ b/packages/gdl-frontend/lib/favorites.js
@@ -1,0 +1,31 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2018 GDL
+ *
+ * See LICENSE
+ */
+import lscache from 'lscache';
+import type { Book } from '../types';
+
+const FAVORITES_KEY = 'favorites';
+
+export function markFavorite(book: Book) {
+  const favs = [...getFavorites(), { id: book.id, lang: book.language.code }];
+  setFavorites(favs);
+}
+
+export function removeFavorite(book: Book) {
+  const favs = getFavorites().filter(
+    fav => fav.id === book.id && fav.lang === book.language.code
+  );
+  setFavorites(favs);
+}
+
+export function getFavorites(): Array<string> {
+  return lscache.get(FAVORITES_KEY) || [];
+}
+
+function setFavorites(favs) {
+  lscache.set(FAVORITES_KEY, favs);
+}

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -89,7 +89,10 @@ const EditBookLink = styled('a')`
 
 const BORDER_STYLE = `1px solid ${colors.base.grayLight}`;
 
-class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
+class BookPage extends React.Component<
+  Props,
+  { anchorEl: ?HTMLElement, isFav: boolean }
+> {
   state = {
     anchorEl: null,
     isFav: false
@@ -237,22 +240,6 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                             </Button>
                           </Link>
                         </Grid>
-<<<<<<< HEAD
-                        <Grid item>
-                          <Button
-                            aria-owns={
-                              this.state.anchorEl ? 'download-book-menu' : null
-                            }
-                            aria-haspopup="true"
-                            color="primary"
-                            onClick={this.handleDownloadClick}
-                          >
-                            <CloudDownloadIcon css={{ marginRight: '10px' }} />
-                            <Trans>Download book</Trans>
-                          </Button>
-                        </Grid>
-=======
->>>>>>> Better faving
                         <Menu
                           id="download-book-menu"
                           onClose={this.closeDownloadMenu}
@@ -329,7 +316,7 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                   <Tab
                     css={{ flexGrow: 1, flexShrink: 1 }}
                     role="button"
-                    icon={<FileDownloadIcon />}
+                    icon={<CloudDownloadIcon />}
                     label={<Trans>Download</Trans>}
                     aria-owns={
                       this.state.anchorEl ? 'download-book-menu' : null

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -128,8 +128,20 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
     this.setState({ isFav: isFavorite(this.props.book) });
   };
 
+  /**
+   * When we mount, check if the book is a user's favorite
+   */
   componentDidMount() {
     this.setState({ isFav: isFavorite(this.props.book) });
+  }
+
+  /**
+   * We need to recalculate the favorite state if the book changes
+   */
+  componentDidUpdate(prevProps) {
+    if (prevProps.book !== this.props.book) {
+      this.setState({ isFav: isFavorite(this.props.book) });
+    }
   }
 
   render() {

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -159,7 +159,10 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
 
               {/* All this flexing on => tablet is because we want to push the buttons down in the card*/}
               <Card
-                css={[{ width: '100%' }, media.tablet({ display: 'flex' })]}
+                css={[
+                  { width: '100%' },
+                  media.tablet({ display: 'flex', flexDirection: 'column' })
+                ]}
               >
                 <CardContent
                   css={[
@@ -296,21 +299,8 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                 <div css={{ display: 'flex' }}>
                   <Tab
                     css={{ flexGrow: 1, flexShrink: 1 }}
-                    role=""
-                    icon={<FileDownloadIcon />}
-                    label={<Trans>Download</Trans>}
-                    aria-owns={
-                      this.state.anchorEl ? 'download-book-menu' : null
-                    }
-                    aria-haspopup="true"
-                    onClick={this.handleDownloadClick}
-                  >
-                    Download
-                  </Tab>
-                  <Tab
-                    css={{ flexGrow: 1, flexShrink: 1 }}
                     onClick={this.handleFavClick}
-                    role=""
+                    role="button"
                     icon={
                       this.state.isFav ? (
                         <FavoriteIcon
@@ -323,6 +313,19 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                     label={<Trans>Favorite</Trans>}
                   >
                     Favorite
+                  </Tab>
+                  <Tab
+                    css={{ flexGrow: 1, flexShrink: 1 }}
+                    role="button"
+                    icon={<FileDownloadIcon />}
+                    label={<Trans>Download</Trans>}
+                    aria-owns={
+                      this.state.anchorEl ? 'download-book-menu' : null
+                    }
+                    aria-haspopup="true"
+                    onClick={this.handleDownloadClick}
+                  >
+                    Download
                   </Tab>
                 </div>
               </Card>

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -19,13 +19,16 @@ import {
   CardContent,
   Typography,
   Divider,
-  Grid
+  Grid,
+  Tab
 } from '@material-ui/core';
 import {
   Edit as EditIcon,
   CloudDownload as CloudDownloadIcon,
   Translate as TranslateIcon,
-  Warning as WarningIcon
+  Warning as WarningIcon,
+  Favorite as FavoriteIcon,
+  FavoriteBorder as FavoriteOutlineIcon
 } from '@material-ui/icons';
 
 import { fetchBook, fetchSimilarBooks } from '../../fetch';
@@ -42,6 +45,11 @@ import { hasClaim, claims } from 'gdl-auth';
 import media from '../../style/media';
 import { colors, spacing } from '../../style/theme';
 import { BookJsonLd, Metadata } from '../../components/BookDetailsPage';
+import {
+  markAsFavorite,
+  removeAsFavorite,
+  isFavorite
+} from '../../lib/favorites';
 
 const {
   publicRuntimeConfig: { zendeskUrl }
@@ -83,7 +91,8 @@ const BORDER_STYLE = `1px solid ${colors.base.grayLight}`;
 
 class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
   state = {
-    anchorEl: null
+    anchorEl: null,
+    isFav: false
   };
 
   static async getInitialProps({ query, req }: Context) {
@@ -110,6 +119,18 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
     this.setState({ anchorEl: event.currentTarget });
 
   closeDownloadMenu = () => this.setState({ anchorEl: null });
+
+  handleFavClick = () => {
+    this.state.isFav
+      ? removeAsFavorite(this.props.book)
+      : markAsFavorite(this.props.book);
+
+    this.setState({ isFav: isFavorite(this.props.book) });
+  };
+
+  componentDidMount() {
+    this.setState({ isFav: isFavorite(this.props.book) });
+  }
 
   render() {
     const { similarBooks, book } = this.props;
@@ -201,6 +222,7 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                             </Button>
                           </Link>
                         </Grid>
+<<<<<<< HEAD
                         <Grid item>
                           <Button
                             aria-owns={
@@ -214,6 +236,8 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                             <Trans>Download book</Trans>
                           </Button>
                         </Grid>
+=======
+>>>>>>> Better faving
                         <Menu
                           id="download-book-menu"
                           onClose={this.closeDownloadMenu}
@@ -269,6 +293,38 @@ class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
                     )}
                   </Grid>
                 </CardContent>
+                <div css={{ display: 'flex' }}>
+                  <Tab
+                    css={{ flexGrow: 1, flexShrink: 1 }}
+                    role=""
+                    icon={<FileDownloadIcon />}
+                    label={<Trans>Download</Trans>}
+                    aria-owns={
+                      this.state.anchorEl ? 'download-book-menu' : null
+                    }
+                    aria-haspopup="true"
+                    onClick={this.handleDownloadClick}
+                  >
+                    Download
+                  </Tab>
+                  <Tab
+                    css={{ flexGrow: 1, flexShrink: 1 }}
+                    onClick={this.handleFavClick}
+                    role=""
+                    icon={
+                      this.state.isFav ? (
+                        <FavoriteIcon
+                          style={this.state.isFav ? { color: 'red' } : null}
+                        />
+                      ) : (
+                        <FavoriteOutlineIcon />
+                      )
+                    }
+                    label={<Trans>Favorite</Trans>}
+                  >
+                    Favorite
+                  </Tab>
+                </div>
               </Card>
             </View>
           </Container>

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -45,11 +45,7 @@ import { hasClaim, claims } from 'gdl-auth';
 import media from '../../style/media';
 import { colors, spacing } from '../../style/theme';
 import { BookJsonLd, Metadata } from '../../components/BookDetailsPage';
-import {
-  markAsFavorite,
-  removeAsFavorite,
-  isFavorite
-} from '../../lib/favorites';
+import Favorite from '../../components/Favorite';
 
 const {
   publicRuntimeConfig: { zendeskUrl }
@@ -89,13 +85,9 @@ const EditBookLink = styled('a')`
 
 const BORDER_STYLE = `1px solid ${colors.base.grayLight}`;
 
-class BookPage extends React.Component<
-  Props,
-  { anchorEl: ?HTMLElement, isFav: boolean }
-> {
+class BookPage extends React.Component<Props, { anchorEl: ?HTMLElement }> {
   state = {
-    anchorEl: null,
-    isFav: false
+    anchorEl: null
   };
 
   static async getInitialProps({ query, req }: Context) {
@@ -122,30 +114,6 @@ class BookPage extends React.Component<
     this.setState({ anchorEl: event.currentTarget });
 
   closeDownloadMenu = () => this.setState({ anchorEl: null });
-
-  handleFavClick = () => {
-    this.state.isFav
-      ? removeAsFavorite(this.props.book)
-      : markAsFavorite(this.props.book);
-
-    this.setState({ isFav: isFavorite(this.props.book) });
-  };
-
-  /**
-   * When we mount, check if the book is a user's favorite
-   */
-  componentDidMount() {
-    this.setState({ isFav: isFavorite(this.props.book) });
-  }
-
-  /**
-   * We need to recalculate the favorite state if the book changes
-   */
-  componentDidUpdate(prevProps) {
-    if (prevProps.book !== this.props.book) {
-      this.setState({ isFav: isFavorite(this.props.book) });
-    }
-  }
 
   render() {
     const { similarBooks, book } = this.props;
@@ -296,23 +264,28 @@ class BookPage extends React.Component<
                   </Grid>
                 </CardContent>
                 <div css={{ display: 'flex' }}>
-                  <Tab
-                    css={{ flexGrow: 1, flexShrink: 1 }}
-                    onClick={this.handleFavClick}
-                    role="button"
-                    icon={
-                      this.state.isFav ? (
-                        <FavoriteIcon
-                          style={this.state.isFav ? { color: 'red' } : null}
-                        />
-                      ) : (
-                        <FavoriteOutlineIcon />
-                      )
-                    }
-                    label={<Trans>Favorite</Trans>}
+                  <Favorite
+                    id={this.props.book.id}
+                    language={this.props.book.language.code}
                   >
-                    Favorite
-                  </Tab>
+                    {({ onClick, isFav }) => (
+                      <Tab
+                        css={{ flexGrow: 1, flexShrink: 1 }}
+                        onClick={onClick}
+                        role="button"
+                        icon={
+                          isFav ? (
+                            <FavoriteIcon
+                              style={isFav ? { color: 'red' } : null}
+                            />
+                          ) : (
+                            <FavoriteOutlineIcon />
+                          )
+                        }
+                        label={<Trans>Favorite</Trans>}
+                      />
+                    )}
+                  </Favorite>
                   <Tab
                     css={{ flexGrow: 1, flexShrink: 1 }}
                     role="button"
@@ -323,9 +296,7 @@ class BookPage extends React.Component<
                     }
                     aria-haspopup="true"
                     onClick={this.handleDownloadClick}
-                  >
-                    Download
-                  </Tab>
+                  />
                 </div>
               </Card>
             </View>

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -18,7 +18,6 @@ import Layout from '../components/Layout';
 import Head from '../components/Head';
 import { Container } from '../elements';
 import { spacing, colors } from '../style/theme';
-import { withMuiRoot } from '../hocs';
 import { getFavorites } from '../lib/favorites';
 import BookGrid from '../components/BookGrid';
 
@@ -36,8 +35,6 @@ class FavoritesPage extends React.Component<{}, State> {
     ).then(bookResults => bookResults.map(bookResult => bookResult.data));
 
     this.setState({ books });
-
-    console.log(books);
   }
 
   render() {
@@ -45,11 +42,11 @@ class FavoritesPage extends React.Component<{}, State> {
     return (
       <>
         <Head title="Favorites" />
-        <Layout crumbs={[<Trans>Favorites</Trans>]}>
+        <Layout>
           <Typography
             align="center"
             variant="headline"
-            css={{ marginTop: spacing.large }}
+            css={{ marginTop: spacing.large, marginBottom: spacing.large }}
           >
             Favorites
           </Typography>
@@ -90,20 +87,4 @@ class FavoritesPage extends React.Component<{}, State> {
   }
 }
 
-/*const Favorite = ({ book, removeFavorite }) => (
-  <Card>
-    <CardContent>
-      <IconButton onClick={() => removeFavorite(book)}>
-        <FavoriteIcon />
-      </IconButton>
-      <Link route={`/${book.language.code}/books/details/${book.id}`} passHref>
-        <Typography component="a" lang={book.language.code}>
-          {book.title}
-        </Typography>
-      </Link>
-      <Typography lang={book.language.code}>{book.description}</Typography>
-    </CardContent>
-  </Card>
-);*/
-
-export default withMuiRoot(FavoritesPage);
+export default FavoritesPage;

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -8,30 +8,89 @@
 
 import * as React from 'react';
 import { Trans } from '@lingui/react';
-import { Typography } from '@material-ui/core';
+import {
+  Typography,
+  IconButton,
+  Card,
+  CardContent,
+  Icon
+} from '@material-ui/core';
+import { Favorite as FavoriteIcon } from '@material-ui/icons';
 
+import { Link } from '../routes';
+import { fetchBook } from '../fetch';
 import type { Book } from '../types';
 import Layout from '../components/Layout';
 import Head from '../components/Head';
 import { Container } from '../elements';
 import { spacing, colors } from '../style/theme';
 import { withMuiRoot } from '../hocs';
+import { getFavorites, removeAsFavorite } from '../lib/favorites';
 
-type State = {};
+type State = {
+  books?: Array<Book>
+};
 
 class FavoritesPage extends React.Component<{}, State> {
   state = {};
+
+  async componentDidMount() {
+    const favs = getFavorites();
+    const books = await Promise.all(
+      favs.map(fav => fetchBook(fav.id, fav.lang))
+    ).then(bookResults => bookResults.map(bookResult => bookResult.data));
+
+    this.setState({ books });
+
+    console.log(books);
+  }
+
+  removeFavorite = book => {
+    removeAsFavorite(book);
+    this.setState(state => ({ books: state.books.filter(b => b !== book) }));
+  };
 
   render() {
     return (
       <>
         <Head title="Favorites" />
-        <Layout crumbs={[<Trans>My favorites</Trans>]}>
+        <Layout crumbs={[<Trans>Favorites</Trans>]}>
           <Typography>Favorites</Typography>
+          {this.state.books &&
+            this.state.books.map(b => (
+              <Favorite
+                key={b.id}
+                book={b}
+                removeFavorite={this.removeFavorite}
+              />
+            ))}
+          {!this.state.books && (
+            <div>
+              <Typography>
+                <Trans>Books you mark as favorites are listed here.</Trans>
+              </Typography>
+            </div>
+          )}
         </Layout>
       </>
     );
   }
 }
+
+const Favorite = ({ book, removeFavorite }) => (
+  <Card>
+    <CardContent>
+      <IconButton onClick={() => removeFavorite(book)}>
+        <FavoriteIcon />
+      </IconButton>
+      <Link route={`/${book.language.code}/books/details/${book.id}`} passHref>
+        <Typography component="a" lang={book.language.code}>
+          {book.title}
+        </Typography>
+      </Link>
+      <Typography lang={book.language.code}>{book.description}</Typography>
+    </CardContent>
+  </Card>
+);
 
 export default withMuiRoot(FavoritesPage);

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -1,0 +1,37 @@
+// @flow
+/**
+ * Part of GDL gdl-frontend.
+ * Copyright (C) 2018 GDL
+ *
+ * See LICENSE
+ */
+
+import * as React from 'react';
+import { Trans } from '@lingui/react';
+import { Typography } from '@material-ui/core';
+
+import type { Book } from '../types';
+import Layout from '../components/Layout';
+import Head from '../components/Head';
+import { Container } from '../elements';
+import { spacing, colors } from '../style/theme';
+import { withMuiRoot } from '../hocs';
+
+type State = {};
+
+class FavoritesPage extends React.Component<{}, State> {
+  state = {};
+
+  render() {
+    return (
+      <>
+        <Head title="Favorites" />
+        <Layout crumbs={[<Trans>My favorites</Trans>]}>
+          <Typography>Favorites</Typography>
+        </Layout>
+      </>
+    );
+  }
+}
+
+export default withMuiRoot(FavoritesPage);

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -8,7 +8,12 @@
 
 import * as React from 'react';
 import { Trans } from '@lingui/react';
-import { Avatar, Button, Typography } from '@material-ui/core';
+import {
+  Avatar,
+  Button,
+  Typography,
+  CircularProgress
+} from '@material-ui/core';
 import { FavoriteBorder as FavoriteBorderIcon } from '@material-ui/icons';
 import Link from 'next/link';
 
@@ -16,71 +21,97 @@ import { fetchBook } from '../fetch';
 import type { Book } from '../types';
 import Layout from '../components/Layout';
 import Head from '../components/Head';
-import { Container } from '../elements';
-import { spacing, colors } from '../style/theme';
+import { Container, Center } from '../elements';
+import { spacing } from '../style/theme';
 import { getFavorites } from '../lib/favorites';
 import BookGrid from '../components/BookGrid';
 
 type State = {
-  books?: Array<Book>
+  books: Array<Book>,
+  loadingStatus: 'LOADING' | 'SUCCESS' | 'ERROR'
 };
 
 class FavoritesPage extends React.Component<{}, State> {
-  state = {};
+  state = {
+    loadingStatus: 'LOADING',
+    books: []
+  };
 
   async componentDidMount() {
     const favs = getFavorites();
-    const books = await Promise.all(
-      favs.map(fav => fetchBook(fav.id, fav.lang))
-    ).then(bookResults => bookResults.map(bookResult => bookResult.data));
 
-    this.setState({ books });
+    const booksResults = await Promise.all(
+      favs.map(fav => fetchBook(fav.id, fav.lang))
+    );
+
+    if (booksResults.some(res => !res.isOk)) {
+      this.setState({ loadingStatus: 'ERROR' });
+    } else {
+      const books = booksResults.map(res => res.data);
+      this.setState({ books, loadingStatus: 'SUCCESS' });
+    }
   }
 
   render() {
-    const books = this.state.books;
+    const { books, loadingStatus } = this.state;
     return (
       <>
         <Head title="Favorites" />
         <Layout>
-          <Typography
-            align="center"
-            variant="headline"
-            css={{ marginTop: spacing.large, marginBottom: spacing.large }}
-          >
-            Favorites
-          </Typography>
-          {books && books.length > 0 && <BookGrid books={books} />}
-          {books &&
-            books.length === 0 && (
-              <div css={{ textAlign: 'center' }}>
-                <div
-                  css={{
-                    display: 'flex',
-                    justifyContent: 'center',
-                    marginTop: spacing.xlarge
-                  }}
-                >
-                  <Avatar css={{ height: 100, width: 100 }}>
-                    <FavoriteBorderIcon css={{ color: 'red', fontSize: 70 }} />
-                  </Avatar>
-                </div>
-                <Typography
-                  css={{
-                    marginTop: spacing.large,
-                    marginBottom: spacing.medium
-                  }}
-                >
-                  <Trans>
-                    Add books to your favorites so you can easily find them
-                    later.
-                  </Trans>
-                </Typography>
-                <Link passHref href="/">
-                  <Button variant="outlined">Find something to read</Button>
-                </Link>
-              </div>
+          <Container>
+            <Typography
+              variant="headline"
+              align="center"
+              css={{ marginTop: spacing.large, marginBottom: spacing.large }}
+            >
+              <Trans>Favorites</Trans>
+            </Typography>
+
+            {loadingStatus === 'LOADING' && (
+              <Center>
+                <CircularProgress />
+              </Center>
             )}
+
+            {loadingStatus === 'ERROR' && (
+              <Typography>
+                <Trans>Unable to load favorites</Trans>
+              </Typography>
+            )}
+
+            {loadingStatus === 'SUCCESS' && (
+              <>
+                {books.length > 0 ? (
+                  <BookGrid books={books} />
+                ) : (
+                  <Center>
+                    <Avatar css={{ height: 100, width: 100 }}>
+                      <FavoriteBorderIcon
+                        css={{ color: 'red', fontSize: 70 }}
+                      />
+                    </Avatar>
+                    <Typography
+                      align="center"
+                      css={{
+                        marginTop: spacing.large,
+                        marginBottom: spacing.medium
+                      }}
+                    >
+                      <Trans>
+                        Add books to your favorites so you can easily find them
+                        later.
+                      </Trans>
+                    </Typography>
+                    <Link passHref href="/">
+                      <Button variant="outlined">
+                        <Trans>Find something to read</Trans>
+                      </Button>
+                    </Link>
+                  </Center>
+                )}
+              </>
+            )}
+          </Container>
         </Layout>
       </>
     );

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -8,16 +8,10 @@
 
 import * as React from 'react';
 import { Trans } from '@lingui/react';
-import {
-  Typography,
-  IconButton,
-  Card,
-  CardContent,
-  Icon
-} from '@material-ui/core';
-import { Favorite as FavoriteIcon } from '@material-ui/icons';
+import { Avatar, Button, Typography } from '@material-ui/core';
+import { FavoriteBorder as FavoriteBorderIcon } from '@material-ui/icons';
+import Link from 'next/link';
 
-import { Link } from '../routes';
 import { fetchBook } from '../fetch';
 import type { Book } from '../types';
 import Layout from '../components/Layout';
@@ -25,7 +19,7 @@ import Head from '../components/Head';
 import { Container } from '../elements';
 import { spacing, colors } from '../style/theme';
 import { withMuiRoot } from '../hocs';
-import { getFavorites, removeAsFavorite } from '../lib/favorites';
+import { getFavorites } from '../lib/favorites';
 import BookGrid from '../components/BookGrid';
 
 type State = {
@@ -46,34 +40,57 @@ class FavoritesPage extends React.Component<{}, State> {
     console.log(books);
   }
 
-  removeFavorite = book => {
-    removeAsFavorite(book);
-    this.setState(state => ({ books: state.books.filter(b => b !== book) }));
-  };
-
   render() {
+    const books = this.state.books;
     return (
       <>
         <Head title="Favorites" />
         <Layout crumbs={[<Trans>Favorites</Trans>]}>
-          <Typography align="center" variant="headline">
+          <Typography
+            align="center"
+            variant="headline"
+            css={{ marginTop: spacing.large }}
+          >
             Favorites
           </Typography>
-          {this.state.books && <BookGrid books={this.state.books} />}
-          {!this.state.books && (
-            <div>
-              <Typography>
-                <Trans>Books you mark as favorites are listed here.</Trans>
-              </Typography>
-            </div>
-          )}
+          {books && books.length > 0 && <BookGrid books={books} />}
+          {books &&
+            books.length === 0 && (
+              <div css={{ textAlign: 'center' }}>
+                <div
+                  css={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    marginTop: spacing.xlarge
+                  }}
+                >
+                  <Avatar css={{ height: 100, width: 100 }}>
+                    <FavoriteBorderIcon css={{ color: 'red', fontSize: 70 }} />
+                  </Avatar>
+                </div>
+                <Typography
+                  css={{
+                    marginTop: spacing.large,
+                    marginBottom: spacing.medium
+                  }}
+                >
+                  <Trans>
+                    Add books to your favorites so you can easily find them
+                    later.
+                  </Trans>
+                </Typography>
+                <Link passHref href="/">
+                  <Button variant="outlined">Find something to read</Button>
+                </Link>
+              </div>
+            )}
         </Layout>
       </>
     );
   }
 }
 
-const Favorite = ({ book, removeFavorite }) => (
+/*const Favorite = ({ book, removeFavorite }) => (
   <Card>
     <CardContent>
       <IconButton onClick={() => removeFavorite(book)}>
@@ -87,6 +104,6 @@ const Favorite = ({ book, removeFavorite }) => (
       <Typography lang={book.language.code}>{book.description}</Typography>
     </CardContent>
   </Card>
-);
+);*/
 
 export default withMuiRoot(FavoritesPage);

--- a/packages/gdl-frontend/pages/favorites.js
+++ b/packages/gdl-frontend/pages/favorites.js
@@ -26,6 +26,7 @@ import { Container } from '../elements';
 import { spacing, colors } from '../style/theme';
 import { withMuiRoot } from '../hocs';
 import { getFavorites, removeAsFavorite } from '../lib/favorites';
+import BookGrid from '../components/BookGrid';
 
 type State = {
   books?: Array<Book>
@@ -55,15 +56,10 @@ class FavoritesPage extends React.Component<{}, State> {
       <>
         <Head title="Favorites" />
         <Layout crumbs={[<Trans>Favorites</Trans>]}>
-          <Typography>Favorites</Typography>
-          {this.state.books &&
-            this.state.books.map(b => (
-              <Favorite
-                key={b.id}
-                book={b}
-                removeFavorite={this.removeFavorite}
-              />
-            ))}
+          <Typography align="center" variant="headline">
+            Favorites
+          </Typography>
+          {this.state.books && <BookGrid books={this.state.books} />}
           {!this.state.books && (
             <div>
               <Typography>

--- a/packages/gdl-frontend/routes.js
+++ b/packages/gdl-frontend/routes.js
@@ -25,6 +25,7 @@ routes.add({
 routes.add('login');
 routes.add('logout');
 routes.add('search');
+routes.add('favorites');
 
 // in other environments we want the books page to be the landing page
 routes.add('books', `/${langParam}?`, 'index');


### PR DESCRIPTION
This pull request adds book favorites.

There is a now a heart button on both the book details page and the when reading book to mark it as a favorite. The favs are kept in local storage, so they work even for users that aren't logged in.

There's also a new page that simply lists all of your favorites (using the same grid of books as when you're browsing books). If any of the call so fetch a particular book fails there is an attempt to remove it from localstorage.

Solves https://github.com/GlobalDigitalLibraryio/issues/issues/398