### PR TITLE
Add expander with additional information for books

### DIFF
--- a/packages/admin-frontend/components/EditBook/EditBookForm.js
+++ b/packages/admin-frontend/components/EditBook/EditBookForm.js
@@ -96,6 +96,18 @@ export default class EditBookForm extends React.Component<Props> {
                       />
                     )}
                   />
+                  <Field
+                    name="additionalInformation"
+                    render={({ input, meta }) => (
+                      <TextField
+                        fullWidth
+                        label="Additional information"
+                        {...input}
+                        error={meta.error && meta.touched}
+                        multiline
+                      />
+                    )}
+                  />
                   <Row>
                     <Field
                       label="Page orientation"

--- a/packages/admin-frontend/types.js
+++ b/packages/admin-frontend/types.js
@@ -104,6 +104,7 @@ export type BookDetails = $ReadOnly<{|
   publisher: Publisher,
   license: License,
   coverImage: CoverImageInfo,
+  additionalInformation?: string,
   supportsTranslation: boolean,
   contributors: Array<Contributor>,
   availableLanguages: Array<Language>,

--- a/packages/gdl-frontend/components/BookDetailsPage/Metadata.js
+++ b/packages/gdl-frontend/components/BookDetailsPage/Metadata.js
@@ -7,8 +7,10 @@
  */
 
 import React, { Fragment } from 'react';
+import { IconButton, Collapse } from '@material-ui/core';
+import { ExpandMore as ExpandMoreIcon } from '@material-ui/icons';
 import { Trans, Plural } from '@lingui/react';
-import styled from 'react-emotion';
+import styled, { css, cx } from 'react-emotion';
 
 import { ContributorTypes, type BookDetails } from '../../types';
 import A from '../../elements/A';
@@ -82,6 +84,11 @@ const BookMeta = ({ book }: Props) => {
         <Trans>License</Trans>
       </Heading>
       <A href={book.license.url}>{book.license.description}</A>
+      {book.additionalInformation && (
+        <AdditionalInformation
+          additionalInformation={book.additionalInformation}
+        />
+      )}
     </Div>
   );
 };
@@ -92,5 +99,69 @@ const Div = styled('div')`
     padding-left: ${spacing.medium};
   `};
 `;
+
+class AdditionalInformation extends React.Component<
+  { additionalInformation: string },
+  { isExpanded: boolean }
+> {
+  state = {
+    isExpanded: false
+  };
+
+  render() {
+    return (
+      <div className={expansionStyles.wrapper}>
+        <div
+          className={expansionStyles.button}
+          role="button"
+          tabIndex="0"
+          aria-expanded={this.state.isExpanded}
+          onClick={() =>
+            this.setState(state => ({ isExpanded: !state.isExpanded }))
+          }
+        >
+          <Heading>
+            <Trans>Additional information</Trans>
+          </Heading>
+          <IconButton
+            className={cx(expansionStyles.iconButton, {
+              [expansionStyles.iconButtonExpanded]: this.state.isExpanded
+            })}
+            tabIndex={-1}
+            aria-hidden
+            component="div"
+          >
+            <ExpandMoreIcon />
+          </IconButton>
+        </div>
+        <Collapse in={this.state.isExpanded}>
+          {this.props.additionalInformation}
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+const expansionStyles = {
+  // We want the wrapper to be the relative parent of the absolutely positioned IconButton.
+  // This is because the focus outline of the button (not the iconbutton) won't have a
+  // weird shape because it includes the size of the iconbutton.
+  wrapper: css`
+    position: relative;
+  `,
+  button: css`
+    user-select: none;
+  `,
+  iconButton: css`
+    position: absolute;
+    top: 10px;
+    right: 8px;
+    transform: translateY(-50%) rotate(0deg);
+    transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  `,
+  iconButtonExpanded: css`
+    transform: translateY(-50%) rotate(180deg);
+  `
+};
 
 export default BookMeta;

--- a/packages/gdl-frontend/types.js
+++ b/packages/gdl-frontend/types.js
@@ -122,6 +122,7 @@ export type BookDetails = $ReadOnly<{|
   publisher: Publisher,
   license: License,
   supportsTranslation: boolean,
+  additionalInformation?: string,
   contributors: Array<Contributor>,
   availableLanguages: Array<Language>,
   chapters: Array<ChapterSummary>,


### PR DESCRIPTION
This pull requests adds an expanding field to the book details page. The field shows any additional information if the book has any.

This is the frontend part of https://github.com/GlobalDigitalLibraryio/issues/issues/461