### PR TITLE
Track metrics of shared books, ignore share cancellations

### DIFF
--- a/packages/gdl-frontend/lib/analytics.js
+++ b/packages/gdl-frontend/lib/analytics.js
@@ -36,6 +36,7 @@ type Action =
   | 'Downloaded ePub'
   | 'Translate'
   | 'Report'
+  | 'Shared'
   // Navigation
   | 'Home'
   | 'Category'

--- a/packages/gdl-frontend/pages/books/_book.js
+++ b/packages/gdl-frontend/pages/books/_book.js
@@ -126,11 +126,14 @@ class BookPage extends React.Component<
 
   handleShareClick = () => {
     if (navigator.share) {
-      navigator.share({
-        title: this.props.book.title,
-        text: this.props.book.description,
-        url: window.location.href
-      });
+      navigator
+        .share({
+          title: this.props.book.title,
+          text: this.props.book.description,
+          url: window.location.href
+        })
+        .then(() => logEvent('Books', 'Shared', this.props.book.title))
+        .catch(() => {}); // Ignore here because we don't care if people cancel sharing
     }
   };
 


### PR DESCRIPTION
If the user cancel's the share action, the promisje rejects, which we
don't really care about

Resolves https://github.com/GlobalDigitalLibraryio/issues/issues/467