### PR TITLE
Add String.prototype.startsWith to list of polyfills

### DIFF
--- a/packages/gdl-frontend/polyfills.js
+++ b/packages/gdl-frontend/polyfills.js
@@ -31,6 +31,10 @@ export default [
     feature: 'String.prototype.includes'
   },
   {
+    test: `('startsWith' in String.prototype)`,
+    feature: 'String.prototype.startsWith'
+  },
+  {
     test: `('values' in Object)`,
     feature: 'Object.values'
   },


### PR DESCRIPTION
Needed by IE11 to not make the signin page crash

Resolves https://github.com/GlobalDigitalLibraryio/issues/issues/484