### PR TITLE
Change analytics library

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "express-request-language": "^1.1.15",
     "facepaint": "1.2.1",
     "final-form": "4.9.1",
+    "ganalytics": "3.1.1",
     "glob": "^7.1.2",
     "helmet": "3.14.0",
     "invariant": "^2.2.4",
@@ -96,7 +97,6 @@
     "react-dom": "16.6.0",
     "react-emotion": "9.2.12",
     "react-final-form": "3.6.5",
-    "react-ga": "2.5.3",
     "react-jss": "8.6.1",
     "react-swipeable": "^4.3.0",
     "universal-cookie": "^2.1.5"

--- a/packages/gdl-frontend/lib/analytics.js
+++ b/packages/gdl-frontend/lib/analytics.js
@@ -1,5 +1,5 @@
 // @flow
-import ReactGA from 'react-ga';
+import GAnalytics from 'ganalytics';
 import getConfig from 'next/config';
 import type { ConfigShape } from '../types';
 
@@ -7,20 +7,16 @@ const {
   publicRuntimeConfig: { googleAnalyticsId }
 }: ConfigShape = getConfig();
 
-let GA_INITIALIZED = false;
+let ga;
 
 export function initGA() {
-  if (googleAnalyticsId && !GA_INITIALIZED) {
-    ReactGA.initialize(googleAnalyticsId);
-    GA_INITIALIZED = true;
+  if (googleAnalyticsId && !ga) {
+    ga = new GAnalytics(googleAnalyticsId, {}, true); // a pageview event will NOT be sent immediately upon initialization
   }
 }
 
 export function logPageView() {
-  if (GA_INITIALIZED) {
-    ReactGA.set({ page: window.location.pathname });
-    ReactGA.pageview(window.location.pathname);
-  }
+  ga && ga.send('pageview');
 }
 
 // Define all allowed categories here, so we are able to group all datapoints correctly
@@ -49,12 +45,7 @@ type Action =
   | 'Added'
   | 'Dismissed';
 
-/**
- * See https://github.com/react-ga/react-ga#reactgaeventargs
- * See https://support.google.com/analytics/answer/1033068?hl=en
- */
 export function logEvent(category: Category, action: Action, label?: string) {
-  if (GA_INITIALIZED) {
-    ReactGA.event({ category, action, label });
-  }
+  // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#events
+  ga && ga.send('event', { ec: category, ea: action, el: label });
 }

--- a/packages/gdl-frontend/package.json
+++ b/packages/gdl-frontend/package.json
@@ -45,6 +45,7 @@
     "express": "4.16.4",
     "express-request-language": "^1.1.15",
     "facepaint": "1.2.1",
+    "ganalytics": "3.1.1",
     "gdl-auth": "^0.0.0",
     "gdl-config": "^0.0.0",
     "gdl-image": "^0.0.0",
@@ -62,7 +63,6 @@
     "react": "16.6.0",
     "react-dom": "16.6.0",
     "react-emotion": "9.2.12",
-    "react-ga": "2.5.3",
     "react-jss": "8.6.1",
     "react-swipeable": "^4.3.0",
     "universal-cookie": "^2.1.5"

--- a/packages/gdl-frontend/pages/_app.js
+++ b/packages/gdl-frontend/pages/_app.js
@@ -22,7 +22,7 @@ import type { Context } from '../types';
 import GdlI18nProvider from '../components/GdlI18nProvider';
 import { LOGOUT_KEY } from '../lib/auth/token';
 import { DEFAULT_TITLE } from '../components/Head';
-import { logPageView, logEvent, initGA } from '../lib/analytics';
+import { initGA, logPageView, logEvent } from '../lib/analytics';
 import { register as registerServiceWorker } from '../registerServiceWorker';
 
 // Adds server generated styles to the emotion cache.
@@ -77,7 +77,7 @@ class App extends NextApp {
       jssStyles.parentNode.removeChild(jssStyles);
     }
 
-    // Setup Google Analytics to log the current page and subsequent other pages
+    // Log the current page in analytics and again on route changes
     initGA();
     logPageView();
     Router.router.events.on('routeChangeComplete', logPageView);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,6 +4369,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+ganalytics@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/ganalytics/-/ganalytics-3.1.1.tgz#d5a1320c8fb42cff4568f789edde98f92089ff56"
+  integrity sha512-q9wANT5JXn83/lvHS1zXdQkRg2wCt/MMCgIsuMCqwRqRo9+u66VEoETNNn3aVcYA8uBqpL2IjkgkbtMwKxqeEA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -8221,14 +8226,6 @@ react-final-form@3.6.5:
   resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-3.6.5.tgz#191324bc686b20e9e49c929a79949f34b38ba8e5"
   integrity sha512-upzvMxpLR0QfNAqZxKZAnqcIxWQhvv3+GHZuoxg31VrIDA/jN70KA2dNnXg6khno9qlAGhtspJMI32j9qYX5lQ==
 
-react-ga@2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.5.3.tgz#0f447c73664c069a5fc341f6f431262e3d4c23c4"
-  integrity sha512-25wvPv1PVLDLhw1gEYP33h0V2sJHahKMfUCAxhq8JPYmNQwx1fcjJAkJk+WmSqGN93lHLhExDkxy3SQizQnx3A==
-  optionalDependencies:
-    prop-types "^15.6.0"
-    react "^15.6.2 || ^16.0"
-
 react-is@^16.3.2, react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
@@ -8283,7 +8280,7 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.6.0, "react@^15.6.2 || ^16.0", react@^16.3.0:
+react@16.6.0, react@^16.3.0:
   version "16.6.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.0.tgz#b34761cfaf3e30f5508bc732fb4736730b7da246"
   integrity sha512-zJPnx/jKtuOEXCbQ9BKaxDMxR0001/hzxXwYxG8septeyYGfsgAei6NgfbVgOhbY1WOP2o3VPs/E9HaN+9hV3Q==


### PR DESCRIPTION
Switching from https://github.com/react-ga/react-ga to https://github.com/lukeed/ganalytics seems to reduce bundle size by ~2 kb