### PR TITLE
Remove unsafe lifecycle method

### DIFF
--- a/packages/gdl-frontend/pages/books/browse.js
+++ b/packages/gdl-frontend/pages/books/browse.js
@@ -86,9 +86,9 @@ class BrowsePage extends React.Component<Props, State> {
     isLoadingMore: false
   };
 
-  componentDidUpdate(nextProps: Props) {
-    if (nextProps.books !== this.props.books) {
-      this.setState({ books: nextProps.books });
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.books !== this.props.books) {
+      this.setState({ books: this.props.books });
     }
   }
 


### PR DESCRIPTION
https://github.com/GlobalDigitalLibraryio/issues/issues/487

Ved bytte til `componentDidUpdate` gjorde jeg feil, fordi den nå mottar `prevProps` og ikke `nextProps`.