### PR TITLE
Change the order of the cloudinary transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ci": "yarn run format:check && yarn run lint && yarn test && yarn run typecheck && yarn build",
     "typecheck": "flow check",
     "test": "jest",
+    "test:watch": "jest --watch",
     "format": "prettier --write \"**/*.js\"",
     "format:check": "prettier --list-different \"**/*.js\"",
     "lint": "eslint . --ext .js --max-warnings=0 --ignore-path .prettierignore",

--- a/packages/gdl-image/__tests__/imageUrl.test.js
+++ b/packages/gdl-image/__tests__/imageUrl.test.js
@@ -1,0 +1,31 @@
+import { imageUrl } from '../';
+
+/**
+ * The order of the transformations matter! Chrome on Android sends request headers that
+ * indicate the device pixel ratio and screen width. Cloudinary can use these values to
+ * optimize the device. If this transformation is in the chain before the transform for
+ * cropped images, than the cropping is skewed because the width of the image has changed.
+ */
+test('it should chain the transformations in the right order', () => {
+  const coverImage = {
+    url:
+      'https://res.cloudinary.com/djylvyru4/f_auto,q_auto/673e68b380bc1a6af69ea00f808bd3f8',
+    imageId: '1234'
+  };
+
+  const url = imageUrl(coverImage, { aspectRatio: 0.81 });
+  const splits = url.split('/');
+
+  // Get the array index of the splits
+  const qualityTransformationIndex = splits.findIndex(s =>
+    s.includes('f_auto')
+  );
+  const ratioTransformationIndex = splits.findIndex(s => s.includes('c_fill'));
+
+  // findIndex returns a negative number for no matches, so ensure we have match
+  expect(qualityTransformationIndex).toBeGreaterThan(0);
+  expect(ratioTransformationIndex).toBeGreaterThan(0);
+
+  // Finally we make sure that the quality transform is the last in the chain
+  expect(qualityTransformationIndex).toBeGreaterThan(ratioTransformationIndex);
+});

--- a/packages/gdl-image/index.js
+++ b/packages/gdl-image/index.js
@@ -67,7 +67,7 @@ export function imageUrl(
   // Since we only receive a whole URL from the backend, we use this trickery to split the url into two parts that we later combine with our transformations
   const [urlPrefix, urlSuffix] = coverImage.url.split(/\/f_auto,q_auto\//);
 
-  return `${urlPrefix}/${defaultTransformations}/${
-    transformations.length ? transformations + '/' : ''
-  }${urlSuffix}`;
+  return `${urlPrefix}/${
+    transformations ? transformations + '/' : ''
+  }${defaultTransformations}/${urlSuffix}`;
 }


### PR DESCRIPTION
On Android Chrome Cloudinary can take advantage of the device width in
the transform, which resultet in skewing when the images where cropped
in a later transform

This resolves https://github.com/GlobalDigitalLibraryio/issues/issues/489