### PR TITLE
fix: Omit credentials in service worker CORS fetch

### DIFF
--- a/packages/gdl-frontend/service-worker.js
+++ b/packages/gdl-frontend/service-worker.js
@@ -14,7 +14,8 @@ workbox.routing.registerRoute(
   workbox.strategies.staleWhileRevalidate({
     cacheName: 'google-fonts-stylesheets',
     fetchOptions: {
-      mode: 'cors'
+      mode: 'cors',
+      credentials: 'omit'
     }
   })
 );


### PR DESCRIPTION
Hopefully this fixes this problem here.

<img width="1069" alt="screenshot 2018-12-06 at 08 36 01" src="https://user-images.githubusercontent.com/81577/49570087-fa234b00-f935-11e8-903a-e05d7b1af44d.png">
