### PR TITLE
error handling lang in url

### DIFF
--- a/packages/gdl-frontend/pages/index.js
+++ b/packages/gdl-frontend/pages/index.js
@@ -63,15 +63,19 @@ class IndexPage extends React.Component<Props> {
       }
     });
 
+    /**
+     * Some valid languages does not have content and will eventually return empty categories.
+     * Fallback/redirect to default language (english).
+     */
     if (categoriesRes.data.categories.length === 0) {
       // We have different ways of redirecting on the server and on the client...
       // See https://github.com/zeit/next.js/wiki/Redirecting-in-%60getInitialProps%60
-      const { code } = DEFAULT_LANGUAGE;
+      const redirectUrl = `/${DEFAULT_LANGUAGE.code}`;
       if (res) {
-        res.writeHead(302, { Location: `/${code}` });
+        res.writeHead(302, { Location: redirectUrl });
         res.end();
       } else {
-        Router.push(`/${code}`);
+        Router.push(redirectUrl);
       }
       return {};
     }

--- a/packages/gdl-frontend/pages/index.js
+++ b/packages/gdl-frontend/pages/index.js
@@ -54,7 +54,7 @@ class IndexPage extends React.Component<Props> {
     apolloClient
   }: Context) {
     // Get the language either from the URL or the user's cookies
-    let languageCode = query.lang || getBookLanguageCode(req);
+    const languageCode = query.lang || getBookLanguageCode(req);
 
     const categoriesRes: { data: Categories } = await apolloClient.query({
       query: CATEGORIES_QUERY,

--- a/packages/gdl-frontend/pages/index.js
+++ b/packages/gdl-frontend/pages/index.js
@@ -20,7 +20,6 @@ import type {
   GetCategories as Categories
 } from '../gqlTypes';
 
-import { isValidLanguageTag } from '../utils/bcp47Validator';
 import { withErrorPage } from '../hocs';
 import HomePage from '../components/HomePage';
 import {
@@ -57,12 +56,6 @@ class IndexPage extends React.Component<Props> {
     // Get the language either from the URL or the user's cookies
     let languageCode = query.lang || getBookLanguageCode(req);
 
-    if (!isValidLanguageTag(languageCode)) {
-      return {
-        statusCode: 404
-      };
-    }
-
     const categoriesRes: { data: Categories } = await apolloClient.query({
       query: CATEGORIES_QUERY,
       variables: {
@@ -73,11 +66,12 @@ class IndexPage extends React.Component<Props> {
     if (categoriesRes.data.categories.length === 0) {
       // We have different ways of redirecting on the server and on the client...
       // See https://github.com/zeit/next.js/wiki/Redirecting-in-%60getInitialProps%60
+      const { code } = DEFAULT_LANGUAGE;
       if (res) {
-        res.writeHead(302, { Location: `/${DEFAULT_LANGUAGE.code}` });
+        res.writeHead(302, { Location: `/${code}` });
         res.end();
       } else {
-        Router.push(`/${DEFAULT_LANGUAGE.code}`);
+        Router.push(`/${code}`);
       }
       return {};
     }

--- a/packages/gdl-frontend/utils/bcp47Validator.js
+++ b/packages/gdl-frontend/utils/bcp47Validator.js
@@ -1,0 +1,6 @@
+// @flow
+const BCP47_REGEXP = /^(?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))$|^((?:[a-z]{2,3}(?:(?:-[a-z]{3}){1,3})?)|[a-z]{4}|[a-z]{5,8})(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?((?:-(?:[\da-z]{5,8}|\d[\da-z]{3}))*)?((?:-[\da-wy-z](?:-[\da-z]{2,8})+)*)?(-x(?:-[\da-z]{1,8})+)?$|^(x(?:-[\da-z]{1,8})+)$/i;
+
+export function isValidLanguageTag(lang: string) {
+  return BCP47_REGEXP.test(lang);
+}

--- a/packages/gdl-frontend/utils/bcp47Validator.js
+++ b/packages/gdl-frontend/utils/bcp47Validator.js
@@ -1,6 +1,0 @@
-// @flow
-const BCP47_REGEXP = /^(?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))$|^((?:[a-z]{2,3}(?:(?:-[a-z]{3}){1,3})?)|[a-z]{4}|[a-z]{5,8})(?:-([a-z]{4}))?(?:-([a-z]{2}|\d{3}))?((?:-(?:[\da-z]{5,8}|\d[\da-z]{3}))*)?((?:-[\da-wy-z](?:-[\da-z]{2,8})+)*)?(-x(?:-[\da-z]{1,8})+)?$|^(x(?:-[\da-z]{1,8})+)$/i;
-
-export function isValidLanguageTag(lang: string) {
-  return BCP47_REGEXP.test(lang);
-}


### PR DESCRIPTION
Fixes https://github.com/GlobalDigitalLibraryio/issues/issues/525

Foreløpig løsning håndterer gyldig språk som er BCP 47 godkjent i url. Om språket ikke returnerer noe innhold, så fallbacker den til engelsk. Hvis språket ikke er godkjent, så kaster den `500` siden.