### PR TITLE
fix: the foremost drawer gets swiped

### DIFF
--- a/packages/gdl-frontend/components/GlobalMenu/CategoriesMenu.js
+++ b/packages/gdl-frontend/components/GlobalMenu/CategoriesMenu.js
@@ -26,6 +26,8 @@ import ReadingLevelTrans from '../ReadingLevelTrans';
 
 type Props = {|
   children: (data: { onClick: () => void, loading: boolean }) => Node,
+  enableParentSwipe: () => void,
+  disableParentSwipe: () => void,
   onSelectCategory: () => void
 |};
 
@@ -66,9 +68,15 @@ export default class CategoriesMenu extends React.Component<
     });
   };
 
-  handleShowMenu = () => this.setState({ showMenu: true });
+  handleShowMenu = () => {
+    this.setState({ showMenu: true });
+    this.props.disableParentSwipe();
+  };
 
-  handleCloseMenu = () => this.setState({ showMenu: false });
+  handleCloseMenu = () => {
+    this.setState({ showMenu: false });
+    this.props.enableParentSwipe();
+  };
 
   render() {
     const { children, onSelectCategory } = this.props;

--- a/packages/gdl-frontend/components/GlobalMenu/SelectBookLanguage.js
+++ b/packages/gdl-frontend/components/GlobalMenu/SelectBookLanguage.js
@@ -19,8 +19,8 @@ type Props = {
   anchor?: 'left' | 'right',
   children: (data: { onClick: () => void, loading: boolean }) => Node,
   onSelectLanguage?: Language => void,
-  enableParentSwipe: () => void,
-  disableParentSwipe: () => void
+  enableParentSwipe?: () => void,
+  disableParentSwipe?: () => void
 };
 
 type State = {
@@ -87,12 +87,12 @@ export default class SelectBookLanguage extends React.Component<Props, State> {
 
   handleShowMenu = () => {
     this.setState({ showMenu: true });
-    this.props.disableParentSwipe();
+    this.props.disableParentSwipe && this.props.disableParentSwipe();
   };
 
   handleCloseMenu = () => {
     this.setState({ showMenu: false });
-    this.props.enableParentSwipe();
+    this.props.enableParentSwipe && this.props.enableParentSwipe();
   };
 
   render() {

--- a/packages/gdl-frontend/components/GlobalMenu/SelectBookLanguage.js
+++ b/packages/gdl-frontend/components/GlobalMenu/SelectBookLanguage.js
@@ -18,7 +18,9 @@ import { getBookLanguageCode } from '../../lib/storage';
 type Props = {
   anchor?: 'left' | 'right',
   children: (data: { onClick: () => void, loading: boolean }) => Node,
-  onSelectLanguage?: Language => void
+  onSelectLanguage?: Language => void,
+  enableParentSwipe: () => void,
+  disableParentSwipe: () => void
 };
 
 type State = {
@@ -83,9 +85,15 @@ export default class SelectBookLanguage extends React.Component<Props, State> {
     this.props.onSelectLanguage && this.props.onSelectLanguage(language);
   };
 
-  handleShowMenu = () => this.setState({ showMenu: true });
+  handleShowMenu = () => {
+    this.setState({ showMenu: true });
+    this.props.disableParentSwipe();
+  };
 
-  handleCloseMenu = () => this.setState({ showMenu: false });
+  handleCloseMenu = () => {
+    this.setState({ showMenu: false });
+    this.props.enableParentSwipe();
+  };
 
   render() {
     const { children, anchor } = this.props;

--- a/packages/gdl-frontend/components/GlobalMenu/index.js
+++ b/packages/gdl-frontend/components/GlobalMenu/index.js
@@ -70,6 +70,7 @@ class GlobalMenu extends React.Component<Props, State> {
         onOpen={() => {}}
         PaperProps={{
           style: {
+            // By setting variant="temporary" a borde right is applied. Which is why it setting it to "inherit" removes it
             borderRight: 'inherit'
           }
         }}
@@ -80,7 +81,11 @@ class GlobalMenu extends React.Component<Props, State> {
         <List>
           {online && (
             <>
-              <SelectBookLanguage onSelectLanguage={onClose}>
+              <SelectBookLanguage
+                onSelectLanguage={onClose}
+                disableParentSwipe={this.disableSwipe}
+                enableParentSwipe={this.enableSwipe}
+              >
                 {({ onClick, loading }) => (
                   <ListItem button onClick={onClick}>
                     <ListItemText>

--- a/packages/gdl-frontend/components/GlobalMenu/index.js
+++ b/packages/gdl-frontend/components/GlobalMenu/index.js
@@ -40,11 +40,13 @@ type Props = {|
 |};
 
 type State = {
+  swipeDisabled: boolean,
   userHasAdminPrivileges: boolean
 };
 
 class GlobalMenu extends React.Component<Props, State> {
   state = {
+    swipeDisabled: false,
     userHasAdminPrivileges: false
   };
 
@@ -54,16 +56,24 @@ class GlobalMenu extends React.Component<Props, State> {
     this.setState({ userHasAdminPrivileges: hasClaim(claims.readAdmin) });
   }
 
+  disableSwipe = () => this.setState({ swipeDisabled: true });
+  enableSwipe = () => this.setState({ swipeDisabled: false });
+
   render() {
     const { onClose } = this.props;
     const online: boolean = this.context;
-
     return (
       <SwipeableDrawer
         disableDiscovery
         disableSwipeToOpen
         disableBackdropTransition
         onOpen={() => {}}
+        PaperProps={{
+          style: {
+            borderRight: 'inherit'
+          }
+        }}
+        variant={this.state.swipeDisabled ? null : 'temporary'}
         open={this.props.isOpen}
         onClose={onClose}
       >
@@ -84,7 +94,11 @@ class GlobalMenu extends React.Component<Props, State> {
                   </ListItem>
                 )}
               </SelectBookLanguage>
-              <CategoriesMenu onSelectCategory={onClose}>
+              <CategoriesMenu
+                onSelectCategory={onClose}
+                disableParentSwipe={this.disableSwipe}
+                enableParentSwipe={this.enableSwipe}
+              >
                 {({ onClick, loading }) => (
                   <ListItem button onClick={onClick}>
                     <ListItemText>


### PR DESCRIPTION
fixes https://github.com/GlobalDigitalLibraryio/issues/issues/526

Feilen er kommentert i denne issuen til MUI: https://github.com/mui-org/material-ui/issues/14064

Workaround: håndtere med egen state for å gjøre nederste drawer ikke swipable.