### PR TITLE
Issue#458: bugfix when changing url to first page, it should not add 0

### DIFF
--- a/packages/gdl-frontend/pages/books/_translate_edit.js
+++ b/packages/gdl-frontend/pages/books/_translate_edit.js
@@ -231,7 +231,8 @@ class TranslateEditPage extends React.Component<Props, State> {
       {
         id: this.props.book.id,
         lang: this.props.book.language.code,
-        chapterId: this.state.current ? this.state.current.id : null
+        // FrontPage is custom made and have been given id 0, which should not be appended in url.
+        chapterId: this.state.current && !!this.state.current.id ? this.state.current.id : null
       },
       { shallow: true }
     );


### PR DESCRIPTION
Var litt rask til å konkludere, men feilen kom av at første siden som jeg har laget har jeg manuelt gitt den `id: 0`. Så `this.state.current.id` er `0`. Regexen tolker det riktig.
