### PR TITLE
#551: Uses the category prop from router if this.props is undefined

### DIFF
--- a/packages/gdl-frontend/pages/books/browse.js
+++ b/packages/gdl-frontend/pages/books/browse.js
@@ -112,7 +112,7 @@ class BrowsePage extends React.Component<Props, State> {
       level: query.readingLevel,
       page: this.state.books.page + 1,
       pageSize: PAGE_SIZE,
-      category: this.props.category,
+      category: this.props.category || this.props.router.query.category,
       sort: 'title'
     });
 

--- a/packages/gdl-frontend/pages/books/browse.js
+++ b/packages/gdl-frontend/pages/books/browse.js
@@ -43,11 +43,11 @@ type Props = {
     query: {
       lang: string,
       readingLevel?: ReadingLevel,
-      category?: string,
+      category?: Category,
       sort?: string
     }
   },
-  category: Category
+  category?: Category
 };
 
 type State = {


### PR DESCRIPTION
Av det jeg fikk testet mot prod så fikk vi undefined når vi prøvde å hente `this.props.category` når vi er inne på `browse` på feks New arrivals (altså etter vi har klikket første gang på 'more'- knappen fra forsiden). Så hvis `this.props.category` er `undefined` så bruker vi den som er satt i `router` (som vi bruker til å mappe ellers i appen andre steder).

Ta gjerne en `checkout` og test :) 
Fixes https://github.com/GlobalDigitalLibraryio/issues/issues/551