### PR TITLE
#557: set test-release tag for Sentry

### DIFF
--- a/packages/gdl-frontend/lib/initSentry.js
+++ b/packages/gdl-frontend/lib/initSentry.js
@@ -18,6 +18,7 @@ const {
 export default function() {
   if (process.env.NODE_ENV === 'production' && REPORT_ERRORS) {
     Sentry.init({
+      release: 'test-release',
       dsn: `https://${SENTRY_PUBLIC_KEY}@sentry.io/${SENTRY_PROJECT_ID}`,
       environment: GDL_ENVIRONMENT
     });

--- a/packages/gdl-frontend/lib/initSentry.js
+++ b/packages/gdl-frontend/lib/initSentry.js
@@ -18,7 +18,7 @@ const {
 export default function() {
   if (process.env.NODE_ENV === 'production' && REPORT_ERRORS) {
     Sentry.init({
-      release: 'test-release',
+      release: '5612c7e633c828ed4dc7b1b4cbab9f37d5ecc73f',
       dsn: `https://${SENTRY_PUBLIC_KEY}@sentry.io/${SENTRY_PROJECT_ID}`,
       environment: GDL_ENVIRONMENT
     });

--- a/packages/gdl-frontend/server/index.js
+++ b/packages/gdl-frontend/server/index.js
@@ -48,6 +48,7 @@ app.prepare().then(() => {
   } else {
     if (REPORT_ERRORS) {
       Sentry.init({
+        release: 'test-release',
         dsn: `https://${SENTRY_PUBLIC_KEY}@sentry.io/${SENTRY_PROJECT_ID}`,
         environment: GDL_ENVIRONMENT
       });

--- a/packages/gdl-frontend/server/index.js
+++ b/packages/gdl-frontend/server/index.js
@@ -48,7 +48,7 @@ app.prepare().then(() => {
   } else {
     if (REPORT_ERRORS) {
       Sentry.init({
-        release: 'test-release',
+        release: '5612c7e633c828ed4dc7b1b4cbab9f37d5ecc73f',
         dsn: `https://${SENTRY_PUBLIC_KEY}@sentry.io/${SENTRY_PROJECT_ID}`,
         environment: GDL_ENVIRONMENT
       });


### PR DESCRIPTION
Vi velger å sette en midlertidig release tag for Sentry slik at vi kan snarest mulig mappe feilmeldingene vi får i Sentry for lettere debugging. Denne taggen gjør ingenting annet at den mapper mot sourcemap i Sentry.

Issue beskrevet her: https://github.com/GlobalDigitalLibraryio/issues/issues/557